### PR TITLE
Dynamic import: enable configuring class components from config.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.yml
+*config.yml
 dist
 *.json
 queries

--- a/config-example.yml
+++ b/config-example.yml
@@ -6,8 +6,12 @@ TASK_SCHEDULER:  # configures: dane_workflows.task_scheduler
   BATCH_SIZE: 5  # number of items returned by DataProvider.get_next_batch
   BATCH_LIMIT: -1 # limit of batches to process (-1 for no limit)
   MONITOR_FREQ: -1  # after each n batches call the STATUS_MONITOR
+STATUS_HANDLER:  # recommended implementation; stores to local file
+  TYPE: dane_workflows.status.SQLiteStatusHandler
+  CONFIG:
+    DB_FILE : ./proc_stats/all_stats.db  # Local file db
 DATA_PROVIDER:  # configures: ExampleDataProvider
-  TYPE: ExampleDataProvider
+  TYPE: dane_workflows.data_provider.ExampleDataProvider
   CONFIG: 
     SOURCE_BATCH_SIZE: 10
     DATA:  # usually DANE environments simply require an ID and content URL to work 
@@ -17,18 +21,8 @@ DATA_PROVIDER:  # configures: ExampleDataProvider
       - 
         id: "video_1"
         url: "https://your_video_files_2.mp4"
-STATUS_HANDLER:  # recommended implementation; stores to local file
-  TYPE: SQLiteStatusHandler
-  CONFIG:
-    DB_FILE : ./proc_stats/all_stats.db  # Local file db
-STATUS_MONITOR:  # optional, for monitoring 
-  TYPE: SlackStatusMonitor
-  CONFIG:
-    TOKEN: "<your token here>"
-    CHANNEL: "<your slack channel here>"
-    WORKFLOW_NAME: "<workflow name here>"
 PROC_ENV:  # to connect to a DANE environment, set TYPE to DANEEnvironment and provide a valid CONFIG
-  TYPE: ExampleDataProcessingEnvironment
+  TYPE: dane_workflows.data_processing.ExampleDataProcessingEnvironment
   # TYPE: DANEEnvironment
   # CONFIG: 
   #   DANE_HOST: "your-dane-host"
@@ -40,6 +34,11 @@ PROC_ENV:  # to connect to a DANE environment, set TYPE to DANEEnvironment and p
   #   DANE_ES_INDEX: 'dane-index-your-env'
   #   DANE_ES_QUERY_TIMEOUT: 20 #seconds?
   #   DANE_BATCH_PREFIX: your_test  # used to track different batches
-
 EXPORTER:  # implement your own Exporter by subclassing from Exporter
-  TYPE: ExampleExporter
+  TYPE: dane_workflows.exporter.ExampleExporter
+STATUS_MONITOR:  # optional, for monitoring 
+  TYPE: dane_workflows.status_monitor.SlackStatusMonitor
+  CONFIG:
+    TOKEN: "<your token here>"
+    CHANNEL: "<your slack channel here>"
+    WORKFLOW_NAME: "<workflow name here>"

--- a/config-example.yml
+++ b/config-example.yml
@@ -22,18 +22,17 @@ DATA_PROVIDER:  # configures: ExampleDataProvider
         id: "video_1"
         url: "https://your_video_files_2.mp4"
 PROC_ENV:  # to connect to a DANE environment, set TYPE to DANEEnvironment and provide a valid CONFIG
-  TYPE: dane_workflows.data_processing.ExampleDataProcessingEnvironment
-  # TYPE: DANEEnvironment
-  # CONFIG: 
-  #   DANE_HOST: "your-dane-host"
-  #   DANE_TASK_ID: "DOWNLOAD"  # tested BG_DOWNLOAD, which works; now testing ASR
-  #   DANE_STATUS_DIR : ../dane_stats
-  #   DANE_MONITOR_INTERVAL: 3  # seconds
-  #   DANE_ES_HOST: 'your-dane-es-host'
-  #   DANE_ES_PORT: 1234
-  #   DANE_ES_INDEX: 'dane-index-your-env'
-  #   DANE_ES_QUERY_TIMEOUT: 20 #seconds?
-  #   DANE_BATCH_PREFIX: your_test  # used to track different batches
+  TYPE: dane_workflows.data_processing.DANEEnvironment
+  CONFIG: 
+    DANE_HOST: "your-dane-host"
+    DANE_TASK_ID: "DOWNLOAD"  # tested BG_DOWNLOAD, which works; now testing ASR
+    DANE_STATUS_DIR : ../dane_stats
+    DANE_MONITOR_INTERVAL: 3  # seconds
+    DANE_ES_HOST: 'your-dane-es-host'
+    DANE_ES_PORT: 1234
+    DANE_ES_INDEX: 'dane-index-your-env'
+    DANE_ES_QUERY_TIMEOUT: 20 #seconds?
+    DANE_BATCH_PREFIX: your_test  # used to track different batches
 EXPORTER:  # implement your own Exporter by subclassing from Exporter
   TYPE: dane_workflows.exporter.ExampleExporter
 STATUS_MONITOR:  # optional, for monitoring 
@@ -42,3 +41,4 @@ STATUS_MONITOR:  # optional, for monitoring
     TOKEN: "<your token here>"
     CHANNEL: "<your slack channel here>"
     WORKFLOW_NAME: "<workflow name here>"
+    INCLUDE_EXTRA_INFO: true

--- a/config-unit-test.yml
+++ b/config-unit-test.yml
@@ -6,19 +6,18 @@ TASK_SCHEDULER:  # configures: dane_workflows.task_scheduler
   BATCH_SIZE: 5  # number of items returned by DataProvider.get_next_batch
   BATCH_LIMIT: -1 # limit of batches to process (-1 for no limit)
   MONITOR_FREQ: -1  # after each n batches call the STATUS_MONITOR
+STATUS_HANDLER:
+  TYPE: dane_workflows.status.ExampleStatusHandler
+  BATCH_PREFIX: your_test  # used to track different iterations of DataProvider.get_next_batch
 DATA_PROVIDER:  # configures: ExampleDataProvider
-  TYPE: ExampleDataProvider
+  TYPE: dane_workflows.data_provider.ExampleDataProvider
   CONFIG: 
     SOURCE_BATCH_SIZE: 10
+PROC_ENV:
+  TYPE: dane_workflows.data_processing.ExampleDataProcessingEnvironment
 EXPORTER:
-  TYPE: ExampleExporter
-STATUS_HANDLER:
-  TYPE: ExampleStatusHandler
+  TYPE: dane_workflows.exporter.ExampleExporter
 STATUS_MONITOR:  # optional, for monitoring 
-  TYPE: ExampleStatusMonitor
+  TYPE: dane_workflows.status_monitor.ExampleStatusMonitor
   CONFIG:
     INCLUDE_EXTRA_INFO: False
-PROC_ENV:
-  TYPE: ExampleDataProcessingEnvironment
-  BATCH_PREFIX: your_test  # used to track different iterations of DataProvider.get_next_batch
-

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -7,6 +7,7 @@ from dane_workflows.util.base_util import (
     check_setting,
     load_config,
     validate_file_paths,
+    init_data_dirs,
 )
 from dane_workflows.status import StatusHandler, StatusRow, ProcessingStatus, ErrorCode
 from dane_workflows.util.dane_util import DANEHandler, Task, Result, TaskType

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -58,7 +58,7 @@ class DataProcessingEnvironment(ABC):
 
         # enforce config validation
         if not self._validate_config():
-            logger.error("Malconfigured, quitting...")
+            logger.critical("Malconfigured, quitting...")
             sys.exit()
 
     def _set_register_batch_failed(

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -49,11 +49,6 @@ If the actual processing environment requires textual input data, either:
 class DataProcessingEnvironment(ABC):
     def __init__(self, config, status_handler: StatusHandler, unit_test: bool = False):
 
-        # check if the configured TYPE is the same as the DataProcessingEnvironment being instantiated
-        if self.__class__.__name__ != config["PROC_ENV"]["TYPE"]:
-            print("Malconfigured class instance")
-            sys.exit()
-
         self.config = (
             config["PROC_ENV"]["CONFIG"] if "CONFIG" in config["PROC_ENV"] else {}
         )

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from dane_workflows.util.base_util import (
     get_logger,
     check_setting,
-    load_config,
+    load_config_or_die,
     auto_create_dir,
 )
 from dane_workflows.status import StatusHandler, StatusRow, ProcessingStatus, ErrorCode
@@ -374,6 +374,6 @@ class ExampleDataProcessingEnvironment(DataProcessingEnvironment):
 if __name__ == "__main__":
     from dane_workflows.status import SQLiteStatusHandler
 
-    config = load_config("../config-example.yml")
+    config = load_config_or_die("../config-example.yml")
     status_handler = SQLiteStatusHandler(config)
     dpe = DANEEnvironment(config, status_handler)

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -6,8 +6,7 @@ from dane_workflows.util.base_util import (
     get_logger,
     check_setting,
     load_config,
-    validate_file_paths,
-    init_data_dirs,
+    auto_create_dir,
 )
 from dane_workflows.status import StatusHandler, StatusRow, ProcessingStatus, ErrorCode
 from dane_workflows.util.dane_util import DANEHandler, Task, Result, TaskType
@@ -213,7 +212,9 @@ class DANEEnvironment(DataProcessingEnvironment):
                 self.config["DANE_ES_QUERY_TIMEOUT"], int
             ), "DANEEnvironment.DANE_ES_QUERY_TIMEOUT"
 
-            validate_file_paths([self.config["DANE_STATUS_DIR"]])  # dir must exist
+            assert (
+                auto_create_dir(self.config["DANE_STATUS_DIR"]) is True
+            ), f"DANE_STATUS_DIR: {self.config['DANE_STATUS_DIR']} auto creation failed"
         except AssertionError as e:
             self.logger.error(f"Configuration error: {str(e)}")
             return False

--- a/dane_workflows/data_provider.py
+++ b/dane_workflows/data_provider.py
@@ -22,10 +22,6 @@ class DataProvider(ABC):
     def __init__(
         self, config: dict, status_handler: StatusHandler, unit_test: bool = False
     ):
-        # check if the configured TYPE is the same as the DataProvider being instantiated
-        if self.__class__.__name__ != config["DATA_PROVIDER"]["TYPE"]:
-            print("Malconfigured class instance")
-            sys.exit()
 
         self.config = config["DATA_PROVIDER"]["CONFIG"]
         self.logger = get_logger(config)  # logging was already initialised by owner

--- a/dane_workflows/data_provider.py
+++ b/dane_workflows/data_provider.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from dane_workflows.util.base_util import (
     get_logger,
     check_setting,
-    load_config,
+    load_config_or_die,
 )
 from dane_workflows.status import StatusHandler, StatusRow, ProcessingStatus
 
@@ -189,6 +189,6 @@ class ExampleDataProvider(DataProvider):
 if __name__ == "__main__":
     from dane_workflows.status import SQLiteStatusHandler
 
-    config = load_config("../config-example.yml")
+    config = load_config_or_die("../config-example.yml")
     status_handler = SQLiteStatusHandler(config)
     dp = ExampleDataProvider(config, status_handler)

--- a/dane_workflows/data_provider.py
+++ b/dane_workflows/data_provider.py
@@ -32,7 +32,7 @@ class DataProvider(ABC):
 
         # enforce config validation
         if not self._validate_config():
-            logger.error("Malconfigured, quitting...")
+            logger.critical("Malconfigured, quitting...")
             sys.exit()
 
     """

--- a/dane_workflows/exporter.py
+++ b/dane_workflows/exporter.py
@@ -22,7 +22,7 @@ class Exporter(ABC):
 
         # enforce config validation
         if not self._validate_config():
-            logger.error("Malconfigured, quitting...")
+            logger.critical("Malconfigured, quitting...")
             sys.exit()
 
         self.status_handler = status_handler

--- a/dane_workflows/exporter.py
+++ b/dane_workflows/exporter.py
@@ -1,14 +1,16 @@
 import sys
 from abc import ABC, abstractmethod
 from typing import List
-
+import logging
 from dane_workflows.data_processing import ProcessingResult
-from dane_workflows.util.base_util import get_logger
 from dane_workflows.status import StatusHandler, ProcessingStatus
 
 """
 This class is owned by a TaskScheduler to export results obtained from a processing environment (such as DANE)
 """
+
+
+logger = logging.getLogger(__name__)
 
 
 class Exporter(ABC):
@@ -18,11 +20,9 @@ class Exporter(ABC):
             config["EXPORTER"]["CONFIG"] if "CONFIG" in config["EXPORTER"] else {}
         )
 
-        self.logger = get_logger(config)  # logging was already initialised by owner
-
         # enforce config validation
         if not self._validate_config():
-            self.logger.error("Malconfigured, quitting...")
+            logger.error("Malconfigured, quitting...")
             sys.exit()
 
         self.status_handler = status_handler
@@ -45,12 +45,12 @@ class ExampleExporter(Exporter):
 
     def export_results(self, results: List[ProcessingResult]) -> bool:
         if not results:
-            self.logger.warning("Received no results for export")
+            logger.warning("Received no results for export")
             return False
-        self.logger.debug(f"Received {len(results)} results to be exported")
+        logger.debug(f"Received {len(results)} results to be exported")
         status_rows = [result.status_row for result in results]
-        self.logger.debug("grab status rows from results")
-        self.logger.debug(status_rows)
+        logger.debug("grab status rows from results")
+        logger.debug(status_rows)
         self.status_handler.persist(  # everything is exported properly
             self.status_handler.update_status_rows(
                 status_rows, status=ProcessingStatus.FINISHED

--- a/dane_workflows/exporter.py
+++ b/dane_workflows/exporter.py
@@ -14,11 +14,6 @@ This class is owned by a TaskScheduler to export results obtained from a process
 class Exporter(ABC):
     def __init__(self, config, status_handler: StatusHandler, unit_test: bool = False):
 
-        # check if the configured TYPE is the same as the Exporter being instantiated
-        if self.__class__.__name__ != config["EXPORTER"]["TYPE"]:
-            print(f"Malconfigured class instance: {config['EXPORTER']['TYPE']}")
-            sys.exit()
-
         self.config = (
             config["EXPORTER"]["CONFIG"] if "CONFIG" in config["EXPORTER"] else {}
         )

--- a/dane_workflows/runner.py
+++ b/dane_workflows/runner.py
@@ -1,48 +1,15 @@
-import sys
 from dane_workflows.util.base_util import import_dane_workflow_module
 from dane_workflows.task_scheduler import TaskScheduler
 
 
 def construct_task_scheduler(config) -> TaskScheduler:
-    if _validate_config(config):
-        return TaskScheduler(
-            config,
-            import_dane_workflow_module(config["STATUS_HANDLER"]["TYPE"]),
-            import_dane_workflow_module(config["DATA_PROVIDER"]["TYPE"]),
-            import_dane_workflow_module(config["PROC_ENV"]["TYPE"]),
-            import_dane_workflow_module(config["EXPORTER"]["TYPE"]),
-            import_dane_workflow_module(config["STATUS_MONITOR"]["TYPE"])
-            if "STATUS_MONITOR" in config
-            else None,
-        )
-    print("Invalid config, quitting")
-    sys.exit()
-
-
-def _validate_config(config) -> bool:
-    try:
-        required_components = [
-            "LOGGING",
-            "TASK_SCHEDULER",
-            "STATUS_HANDLER",
-            "DATA_PROVIDER",
-            "PROC_ENV",
-            "EXPORTER",
-        ]
-        assert all(
-            component in config for component in required_components
-        ), f"Error one or more {required_components} missing in config"
-
-        # check if the optional status monitor is there
-        if "STATUS_MONITOR" in config:
-            required_components.append("STATUS_MONITOR")
-
-        # some components MUST have a TYPE defined
-        for component in required_components:
-            if component in ["TASK_SCHEDULER", "LOGGING"]:  # no TYPE needed for these
-                continue
-            assert "TYPE" in config[component], f"{component}.TYPE missing"
-    except AssertionError as e:
-        print(e)
-        return False
-    return True
+    return TaskScheduler(
+        config,
+        import_dane_workflow_module(config["STATUS_HANDLER"]["TYPE"]),
+        import_dane_workflow_module(config["DATA_PROVIDER"]["TYPE"]),
+        import_dane_workflow_module(config["PROC_ENV"]["TYPE"]),
+        import_dane_workflow_module(config["EXPORTER"]["TYPE"]),
+        import_dane_workflow_module(config["STATUS_MONITOR"]["TYPE"])
+        if "STATUS_MONITOR" in config
+        else None,
+    )

--- a/dane_workflows/runner.py
+++ b/dane_workflows/runner.py
@@ -1,5 +1,5 @@
 import sys
-from dane_workflows.util.base_util import import_module
+from dane_workflows.util.base_util import import_dane_workflow_module
 from dane_workflows.task_scheduler import TaskScheduler
 
 
@@ -7,11 +7,11 @@ def construct_task_scheduler(config) -> TaskScheduler:
     if _validate_config(config):
         return TaskScheduler(
             config,
-            import_module(config["STATUS_HANDLER"]["TYPE"]),
-            import_module(config["DATA_PROVIDER"]["TYPE"]),
-            import_module(config["PROC_ENV"]["TYPE"]),
-            import_module(config["EXPORTER"]["TYPE"]),
-            import_module(config["STATUS_MONITOR"]["TYPE"])
+            import_dane_workflow_module(config["STATUS_HANDLER"]["TYPE"]),
+            import_dane_workflow_module(config["DATA_PROVIDER"]["TYPE"]),
+            import_dane_workflow_module(config["PROC_ENV"]["TYPE"]),
+            import_dane_workflow_module(config["EXPORTER"]["TYPE"]),
+            import_dane_workflow_module(config["STATUS_MONITOR"]["TYPE"])
             if "STATUS_MONITOR" in config
             else None,
         )

--- a/dane_workflows/runner.py
+++ b/dane_workflows/runner.py
@@ -1,4 +1,4 @@
-from dane_workflows.util.base_util import import_dane_workflow_module
+from dane_workflows.util.base_util import import_dane_workflow_class
 from dane_workflows.task_scheduler import TaskScheduler
 import logging
 
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 def construct_task_scheduler(config) -> TaskScheduler:
     return TaskScheduler(
         config,
-        import_dane_workflow_module(config["STATUS_HANDLER"]["TYPE"]),
-        import_dane_workflow_module(config["DATA_PROVIDER"]["TYPE"]),
-        import_dane_workflow_module(config["PROC_ENV"]["TYPE"]),
-        import_dane_workflow_module(config["EXPORTER"]["TYPE"]),
-        import_dane_workflow_module(config["STATUS_MONITOR"]["TYPE"])
+        import_dane_workflow_class(config["STATUS_HANDLER"]["TYPE"]),
+        import_dane_workflow_class(config["DATA_PROVIDER"]["TYPE"]),
+        import_dane_workflow_class(config["PROC_ENV"]["TYPE"]),
+        import_dane_workflow_class(config["EXPORTER"]["TYPE"]),
+        import_dane_workflow_class(config["STATUS_MONITOR"]["TYPE"])
         if "STATUS_MONITOR" in config
         else None,
     )

--- a/dane_workflows/runner.py
+++ b/dane_workflows/runner.py
@@ -1,5 +1,9 @@
 from dane_workflows.util.base_util import import_dane_workflow_module
 from dane_workflows.task_scheduler import TaskScheduler
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def construct_task_scheduler(config) -> TaskScheduler:

--- a/dane_workflows/runner.py
+++ b/dane_workflows/runner.py
@@ -1,0 +1,48 @@
+import sys
+from dane_workflows.util.base_util import import_module
+from dane_workflows.task_scheduler import TaskScheduler
+
+
+def construct_task_scheduler(config) -> TaskScheduler:
+    if _validate_config(config):
+        return TaskScheduler(
+            config,
+            import_module(config["STATUS_HANDLER"]["TYPE"]),
+            import_module(config["DATA_PROVIDER"]["TYPE"]),
+            import_module(config["PROC_ENV"]["TYPE"]),
+            import_module(config["EXPORTER"]["TYPE"]),
+            import_module(config["STATUS_MONITOR"]["TYPE"])
+            if "STATUS_MONITOR" in config
+            else None,
+        )
+    print("Invalid config, quitting")
+    sys.exit()
+
+
+def _validate_config(config) -> bool:
+    try:
+        required_components = [
+            "LOGGING",
+            "TASK_SCHEDULER",
+            "STATUS_HANDLER",
+            "DATA_PROVIDER",
+            "PROC_ENV",
+            "EXPORTER",
+        ]
+        assert all(
+            component in config for component in required_components
+        ), f"Error one or more {required_components} missing in config"
+
+        # check if the optional status monitor is there
+        if "STATUS_MONITOR" in config:
+            required_components.append("STATUS_MONITOR")
+
+        # some components MUST have a TYPE defined
+        for component in required_components:
+            if component in ["TASK_SCHEDULER", "LOGGING"]:  # no TYPE needed for these
+                continue
+            assert "TYPE" in config[component], f"{component}.TYPE missing"
+    except AssertionError as e:
+        print(e)
+        return False
+    return True

--- a/dane_workflows/status.py
+++ b/dane_workflows/status.py
@@ -124,7 +124,7 @@ class StatusHandler(ABC):
 
         # enforce config validation
         if not self._validate_config():
-            logger.error("Malconfigured, quitting...")
+            logger.critical("Malconfigured, quitting...")
             sys.exit()
 
     """ ------------------------------------ ABSTRACT FUNCTIONS -------------------------------- """
@@ -434,7 +434,7 @@ class SQLiteStatusHandler(StatusHandler):
         super().__init__(config)
         self.DB_FILE: str = self.config["DB_FILE"]
         if self._init_database() is False:
-            logger.debug(f"Could not initialize the DB: {self.DB_FILE}")
+            logger.critical(f"Could not initialize the DB: {self.DB_FILE}")
             sys.exit()
 
     def _init_database(self):

--- a/dane_workflows/status.py
+++ b/dane_workflows/status.py
@@ -111,11 +111,6 @@ class StatusRow:
 class StatusHandler(ABC):
     def __init__(self, config):
 
-        # check if the configured TYPE is the same as the StatusHandler being instantiated
-        if self.__class__.__name__ != config["STATUS_HANDLER"]["TYPE"]:
-            print("Malconfigured class instance")
-            sys.exit()
-
         # only used so the data provider knows which source_batch it was at
         self.cur_source_batch: List[StatusRow] = None  # call recover to fill it
         self.logger = get_logger(config)

--- a/dane_workflows/status.py
+++ b/dane_workflows/status.py
@@ -8,7 +8,7 @@ from dane_workflows.util.base_util import (
     get_logger,
     check_setting,
     load_config,
-    validate_file_paths,
+    auto_create_dir,
 )
 import sqlite3
 from datetime import datetime
@@ -454,9 +454,12 @@ class SQLiteStatusHandler(StatusHandler):
             assert check_setting(
                 self.config["DB_FILE"], str
             ), "SQLiteStatusHandler.DB_FILE"
-            validate_file_paths(
-                [Path(self.config["DB_FILE"]).parent]
-            )  # parent dir must exist
+
+            # auto create the parent dir of the db file
+            db_file_par_dir = Path(self.config["DB_FILE"]).parent
+            assert (
+                auto_create_dir(db_file_par_dir) is True
+            ), f"DB_FILE: {db_file_par_dir} auto creation failed"
         except AssertionError as e:
             self.logger.error(f"Configuration error: {str(e)}")
             return False

--- a/dane_workflows/status.py
+++ b/dane_workflows/status.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from dane_workflows.util.base_util import (
     get_logger,
     check_setting,
-    load_config,
+    load_config_or_die,
     auto_create_dir,
 )
 import sqlite3
@@ -897,5 +897,5 @@ class SQLiteStatusHandler(StatusHandler):
 # test your StatusHandler in isolation
 if __name__ == "__main__":
 
-    config = load_config("../config-example.yml")
+    config = load_config_or_die("../config-example.yml")
     status_handler = SQLiteStatusHandler(config)

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -27,7 +27,7 @@ class StatusMonitor(ABC):
 
         # enforce config validation
         if not self._validate_config():
-            logger.error("Malconfigured, quitting...")
+            logger.critical("Malconfigured, quitting...")
             sys.exit()
 
     def _validate_config(self) -> bool:

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -10,7 +10,7 @@ from dane_workflows.status import (
     ProcessingStatus,
     ErrorCode,
 )
-from dane_workflows.util.base_util import get_logger, check_setting, load_config
+from dane_workflows.util.base_util import get_logger, check_setting, load_config_or_die
 
 
 class StatusMonitor(ABC):
@@ -35,11 +35,11 @@ class StatusMonitor(ABC):
         try:
             assert all(
                 [x in self.config for x in ["INCLUDE_EXTRA_INFO"]]
-            ), "STATUS_MONITOR.keys"
+            ), "StatusMonitor.INCLUDE_EXTRA_INFO missing"
 
             assert check_setting(
                 self.config["INCLUDE_EXTRA_INFO"], bool
-            ), "StatusMonitor.INCLUDE_EXTRA_INFO"
+            ), "StatusMonitor.INCLUDE_EXTRA_INFO not a bool"
 
         except AssertionError as e:
             self.logger.error(f"Configuration error: {str(e)}")
@@ -238,6 +238,7 @@ class SlackStatusMonitor(StatusMonitor):
         if not StatusMonitor._validate_config(
             self
         ):  # if superclass validate fails, all fails
+            self.logger.error("StatusMonitor default config section not valid")
             return False
         else:
             try:
@@ -361,7 +362,7 @@ if __name__ == "__main__":
     """Call this to test your chosen StatusMonitor independently.
     It will then run on the status handler specified in the config"""
 
-    config = load_config(
+    config = load_config_or_die(
         "../config-example.yml"
     )  # TODO: how do we get this to work from within a workflow with the correct config?
     status_handler = ExampleStatusHandler(config)

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -16,12 +16,6 @@ from dane_workflows.util.base_util import get_logger, check_setting, load_config
 class StatusMonitor(ABC):
     def __init__(self, config: dict, status_handler: StatusHandler):
         self.status_handler = status_handler
-
-        # check if the configured TYPE is the same as the StatusMonitor being instantiated
-        if self.__class__.__name__ != config["STATUS_MONITOR"]["TYPE"]:
-            print("Malconfigured class instance")
-            sys.exit()
-
         self.logger = get_logger(config)
         self.config = (
             config["STATUS_MONITOR"]["CONFIG"]

--- a/dane_workflows/task_scheduler.py
+++ b/dane_workflows/task_scheduler.py
@@ -96,7 +96,7 @@ class TaskScheduler(object):
                     self.config["TASK_SCHEDULER"]["MONITOR_FREQ"], int
                 ), "TASK_SCHEDULER.MONITOR_FREQ"
         except AssertionError as e:
-            print(f"Configuration error: {str(e)}")
+            logger.error(f"Configuration error: {str(e)}")
             return False
 
         return True
@@ -112,7 +112,7 @@ class TaskScheduler(object):
             self.data_provider
         )
         if source_batch_recovered is False:
-            logger.info(
+            logger.warning(
                 "Could not recover source_batch, so either the work was done or something is wrong with the DataProvider, quitting"
             )
             sys.exit()

--- a/dane_workflows/task_scheduler.py
+++ b/dane_workflows/task_scheduler.py
@@ -93,10 +93,7 @@ class TaskScheduler(object):
             # check settings for this class
             assert "TASK_SCHEDULER" in self.config, "TASK_SCHEDULER"
             assert all(
-                [
-                    x in self.config["TASK_SCHEDULER"]
-                    for x in ["BATCH_SIZE"]
-                ]
+                [x in self.config["TASK_SCHEDULER"] for x in ["BATCH_SIZE"]]
             ), "TASK_SCHEDULER.keys"
             assert base_util.check_setting(
                 self.config["TASK_SCHEDULER"]["BATCH_SIZE"], int

--- a/dane_workflows/task_scheduler.py
+++ b/dane_workflows/task_scheduler.py
@@ -330,32 +330,3 @@ class TaskScheduler(object):
 
         self.logger.info(f"Successfully exported proc_batch {proc_batch_id} output")
         return True
-
-
-# test a full workflow
-if __name__ == "__main__":
-    from dane_workflows.util.base_util import load_config
-    from dane_workflows.status import SQLiteStatusHandler
-    from dane_workflows.data_provider import ExampleDataProvider
-    from dane_workflows.data_processing import (
-        ExampleDataProcessingEnvironment,
-        # DANEEnvironment,
-    )
-    from dane_workflows.exporter import ExampleExporter
-    from dane_workflows.status_monitor import ExampleStatusMonitor
-
-    print("Starting task scheduler")
-    config = load_config("../config.yml")
-
-    # print(config)
-
-    ts = TaskScheduler(
-        config,
-        SQLiteStatusHandler,
-        ExampleDataProvider,
-        ExampleDataProcessingEnvironment,
-        ExampleExporter,
-        ExampleStatusMonitor,
-    )
-
-    ts.run()

--- a/dane_workflows/task_scheduler.py
+++ b/dane_workflows/task_scheduler.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from typing import List, Type, Tuple, Optional
 from dane_workflows.util import base_util
 from dane_workflows.data_provider import DataProvider, ProcessingStatus
@@ -22,6 +23,9 @@ these implementations with the specific parameters they require.
 """
 
 
+logger = logging.getLogger(__name__)
+
+
 class TaskScheduler(object):
     def __init__(
         self,
@@ -34,10 +38,9 @@ class TaskScheduler(object):
         unit_test: bool = False,
     ):
         self.config = config
-        self.logger = base_util.get_logger(config)  # first init the logger
 
         if not self._validate_config():
-            self.logger.critical("Malconfigured, quitting...")
+            logger.critical("Malconfigured, quitting...")
             sys.exit()
             return  # in unit tests, sys.exit is mocked, so return
 
@@ -109,7 +112,7 @@ class TaskScheduler(object):
             self.data_provider
         )
         if source_batch_recovered is False:
-            self.logger.info(
+            logger.info(
                 "Could not recover source_batch, so either the work was done or something is wrong with the DataProvider, quitting"
             )
             sys.exit()
@@ -119,7 +122,7 @@ class TaskScheduler(object):
 
         if last_proc_batch:
             last_proc_batch_id = self.status_handler.get_last_proc_batch_id()
-            self.logger.info("Synchronizing last proc_batch with ProcessingEnvironment")
+            logger.info("Synchronizing last proc_batch with ProcessingEnvironment")
 
             # determine where to resume processing by looking at the highest step in the chain
             highest_proc_stat = 0
@@ -148,16 +151,14 @@ class TaskScheduler(object):
 
         # if a proc_batch was recovered, make sure to finish it from the last ProcessingStatus
         if last_proc_batch:
-            self.logger.info(
-                f"Recovered proc_batch {last_proc_batch_id}, finishing it up"
-            )
+            logger.info(f"Recovered proc_batch {last_proc_batch_id}, finishing it up")
             if (
                 self._run_proc_batch(last_proc_batch, last_proc_batch_id, skip_steps)
                 is True
             ):
                 last_proc_batch_id += 1  # continue on
             else:
-                self.logger.critical("Critical error whilst processing, quitting")
+                logger.critical("Critical error whilst processing, quitting")
 
         # ok now that the recovered proc_batch has completed, continue on from this proc_batch_id
         proc_batch_id = last_proc_batch_id
@@ -167,13 +168,13 @@ class TaskScheduler(object):
             # first get the next proc_batch from the DataProvider
             status_rows = self._get_next_proc_batch(proc_batch_id, self.BATCH_SIZE)
             if status_rows is None:
-                self.logger.info("No source_batch remaining, all done, quitting...")
+                logger.info("No source_batch remaining, all done, quitting...")
                 break
 
             # now that we have a new proc_batch, pass it on to the ProcessingEnvironment
             # and eventually the Exporter
             if self._run_proc_batch(status_rows, proc_batch_id) is False:
-                self.logger.critical("Critical error whilst processing, quitting")
+                logger.critical("Critical error whilst processing, quitting")
                 break
 
             # update the proc_batch_id and continue on to the next
@@ -188,7 +189,7 @@ class TaskScheduler(object):
     def _get_next_proc_batch(
         self, proc_batch_id: int, batch_size: int
     ) -> Optional[List[StatusRow]]:
-        self.logger.info(
+        logger.info(
             f"asking DataProvider for next batch: {proc_batch_id} ({batch_size})"
         )
         return self.data_provider.get_next_batch(proc_batch_id, batch_size)
@@ -196,7 +197,7 @@ class TaskScheduler(object):
     def _check_batch_limit(self, proc_batch_id):
         if self.BATCH_LIMIT >= 0:
             if proc_batch_id >= self.BATCH_LIMIT:
-                self.logger.info(
+                logger.info(
                     f"Limit of batches (i.e. {self.BATCH_LIMIT}) reached, stopped processing"
                 )
                 sys.exit()
@@ -213,14 +214,14 @@ class TaskScheduler(object):
     def _run_proc_batch(
         self, status_rows: List[StatusRow], proc_batch_id: int, skip_steps: int = 0
     ) -> bool:
-        self.logger.info("Check the limit of batches to process")
+        logger.info("Check the limit of batches to process")
         self._check_batch_limit(proc_batch_id)
 
-        self.logger.info(
+        logger.info(
             f"Processing proc_batch {proc_batch_id}, skipping {skip_steps} steps"
         )
         if skip_steps >= 5:
-            self.logger.warning(
+            logger.warning(
                 f"Warning: why are you skipping so many (i.e. {skip_steps}) steps?"
             )
             return True
@@ -255,38 +256,36 @@ class TaskScheduler(object):
     def _register_proc_batch(
         self, proc_batch_id: int, proc_batch: List[StatusRow]
     ) -> bool:
-        self.logger.info(f"Registering batch: {proc_batch_id}")
+        logger.info(f"Registering batch: {proc_batch_id}")
         status_rows = self.data_processing_env.register_batch(proc_batch_id, proc_batch)
         if status_rows is None:
-            self.logger.error(f"Could not register batch {proc_batch_id}, quitting")
+            logger.error(f"Could not register batch {proc_batch_id}, quitting")
             return False
-        self.logger.info(f"Successfully registered batch: {proc_batch_id}")
+        logger.info(f"Successfully registered batch: {proc_batch_id}")
         return True
 
     # calls the ProcessingEnvironment to start processing the proc_batch
     def _process_proc_batch(self, proc_batch_id: int) -> bool:
-        self.logger.info(f"Triggering proc_batch to start processing: {proc_batch_id}")
+        logger.info(f"Triggering proc_batch to start processing: {proc_batch_id}")
         status_rows = self.data_processing_env.process_batch(proc_batch_id)
         if status_rows is None:
-            self.logger.error(
+            logger.error(
                 f"Could not trigger proc_batch {proc_batch_id} to start processing, quitting"
             )
             return False
-        self.logger.info(f"Successfully triggered the process for: {proc_batch_id}")
+        logger.info(f"Successfully triggered the process for: {proc_batch_id}")
         return True
 
     # calls the ProcessingEnvironment to start monitoring the progress of the proc_batch
     def _monitor_proc_batch(self, proc_batch_id: int) -> bool:
-        self.logger.info(
-            f"Start monitoring proc_batch until it finishes: {proc_batch_id}"
-        )
+        logger.info(f"Start monitoring proc_batch until it finishes: {proc_batch_id}")
         status_rows = self.data_processing_env.monitor_batch(proc_batch_id)
         if status_rows is None:
-            self.logger.error(
+            logger.error(
                 f"Error while monitoring proc_batch: {proc_batch_id}, quitting"
             )
             return False
-        self.logger.info(
+        logger.info(
             f"Successfully monitored proc_batch: {proc_batch_id} till it finished"
         )
         return True
@@ -295,26 +294,24 @@ class TaskScheduler(object):
     def _fetch_proc_batch_output(
         self, proc_batch_id: int
     ) -> Optional[List[ProcessingResult]]:
-        self.logger.info(f"Fetching output data for proc_batch: {proc_batch_id}")
+        logger.info(f"Fetching output data for proc_batch: {proc_batch_id}")
         output = self.data_processing_env.fetch_results_of_batch(proc_batch_id)
         if output is None:
-            self.logger.error(
+            logger.error(
                 f"Did not receive any processing results for {proc_batch_id}, quitting"
             )
             return None
-        self.logger.info(
-            f"Successfully retrieved output for proc_batch {proc_batch_id}"
-        )
+        logger.info(f"Successfully retrieved output for proc_batch {proc_batch_id}")
         return output
 
     # calls the Exporter to export the processing output of the proc_batch
     def _export_proc_batch_output(
         self, proc_batch_id: int, processing_results: List[ProcessingResult]
     ) -> bool:
-        self.logger.info(f"Exporting proc_batch output: {proc_batch_id}")
+        logger.info(f"Exporting proc_batch output: {proc_batch_id}")
         if not self.exporter.export_results(processing_results):
-            self.logger.warning(f"Could not export proc_batch {proc_batch_id} output")
+            logger.warning(f"Could not export proc_batch {proc_batch_id} output")
             return False
 
-        self.logger.info(f"Successfully exported proc_batch {proc_batch_id} output")
+        logger.info(f"Successfully exported proc_batch {proc_batch_id} output")
         return True

--- a/dane_workflows/util/base_util.py
+++ b/dane_workflows/util/base_util.py
@@ -5,7 +5,7 @@ from logging.handlers import TimedRotatingFileHandler
 from yaml import load, FullLoader
 from yaml.scanner import ScannerError
 from pathlib import Path
-
+from importlib import import_module
 
 # returns the root of this repo by running "cd ../.." from this __file__ on
 def get_repo_root() -> str:
@@ -95,12 +95,13 @@ def load_config(cfg_file):
     return None
 
 
-def import_module(module_path: str):
+def import_dane_workflow_module(module_path: str):
     tmp = module_path.split(".")
     if len(tmp) != 3:
         print(f"Malconfigured module path: {module_path}")
         sys.exit()
-    module = getattr(__import__(tmp[0]), tmp[1])
+    # module = getattr(__import__(tmp[0]), tmp[1])
+    module = import_module(f"{tmp[0]}.{tmp[1]}")
     workflow_class = getattr(module, tmp[2])
     # globals()[tmp[2]] = workflow_class
     return workflow_class

--- a/dane_workflows/util/base_util.py
+++ b/dane_workflows/util/base_util.py
@@ -1,9 +1,11 @@
 import os
+import sys
 import logging
 from logging.handlers import TimedRotatingFileHandler
 from yaml import load, FullLoader
 from yaml.scanner import ScannerError
 from pathlib import Path
+from typing import List
 
 
 # returns the root of this repo by running "cd ../.." from this __file__ on
@@ -72,6 +74,30 @@ def load_config(cfg_file):
     except (FileNotFoundError, ScannerError) as e:
         print(e)
     return None
+
+
+def init_data_dirs(data_dirs: List[str]) -> bool:
+    print("Checking if DATA_DIR exists")
+    for path in data_dirs:
+        if not os.path.exists(path):
+            print(f"path: '{path}' does not exist, creating it...")
+            try:
+                os.makedirs(path)
+            except OSError:
+                print(f"OSError {path} could not be created...")
+                return False
+    return True
+
+
+def import_module(module_path: str):
+    tmp = module_path.split(".")
+    if len(tmp) != 3:
+        print(f"Malconfigured module path: {module_path}")
+        sys.exit()
+    module = getattr(__import__(tmp[0]), tmp[1])
+    workflow_class = getattr(module, tmp[2])
+    # globals()[tmp[2]] = workflow_class
+    return workflow_class
 
 
 def init_logger(config):

--- a/dane_workflows/util/base_util.py
+++ b/dane_workflows/util/base_util.py
@@ -39,7 +39,7 @@ def load_config_or_die(cfg_file: str):
             if validate_config(config):
                 return config
             else:
-                logger.info(f"Config: {cfg_file} invalid, quitting")
+                logger.critical(f"Config: {cfg_file} invalid, quitting")
                 sys.exit()
     except (FileNotFoundError, ScannerError):
         logger.exception(f"Not a valid file path or config file {cfg_file}")
@@ -166,13 +166,12 @@ def auto_create_dir(path: str) -> bool:
     return True
 
 
-def import_dane_workflow_module(module_path: str):
-    tmp = module_path.split(".")
-    if len(tmp) != 3:
-        logger.critical(f"Malconfigured module path: {module_path}")
+def import_dane_workflow_class(class_path: str):
+    tmp = class_path.split(".")
+    if len(tmp) < 2:  # always specify modulepath.class
+        logger.critical(f"Malconfigured module path: {class_path}")
         sys.exit()
-    # module = getattr(__import__(tmp[0]), tmp[1])
-    module = import_module(f"{tmp[0]}.{tmp[1]}")
-    workflow_class = getattr(module, tmp[2])
-    # globals()[tmp[2]] = workflow_class
+    module_path = ".".join(tmp[:-1])
+    module = import_module(f"{module_path}")
+    workflow_class = getattr(module, tmp[-1])  # last element is the class name
     return workflow_class

--- a/dane_workflows/util/base_util.py
+++ b/dane_workflows/util/base_util.py
@@ -67,6 +67,25 @@ def validate_file_paths(paths: list):
         raise (e)
 
 
+def get_parent_dir(path: str) -> str:
+    return Path(path).parent
+
+
+# the parent dir of the configured directory has to exist for this to work
+def auto_create_dir(path: str) -> bool:
+    print(f"Trying to automatically create dir: {path}")
+    if not os.path.exists(get_parent_dir(path)):
+        print(f"Error: cannot automatically create {path}; parent dir does not exist")
+        return False
+    if not os.path.exists(path):
+        print(f"Dir: '{path}' does not exist, creating it...")
+        try:
+            os.makedirs(path)
+        except OSError:
+            print(f"OSError {path} could not be created...")
+            return False
+    return True
+
 def load_config(cfg_file):
     try:
         with open(cfg_file, "r") as yamlfile:
@@ -74,19 +93,6 @@ def load_config(cfg_file):
     except (FileNotFoundError, ScannerError) as e:
         print(e)
     return None
-
-
-def init_data_dirs(data_dirs: List[str]) -> bool:
-    print("Checking if DATA_DIR exists")
-    for path in data_dirs:
-        if not os.path.exists(path):
-            print(f"path: '{path}' does not exist, creating it...")
-            try:
-                os.makedirs(path)
-            except OSError:
-                print(f"OSError {path} could not be created...")
-                return False
-    return True
 
 
 def import_module(module_path: str):

--- a/dane_workflows/util/base_util.py
+++ b/dane_workflows/util/base_util.py
@@ -5,7 +5,6 @@ from logging.handlers import TimedRotatingFileHandler
 from yaml import load, FullLoader
 from yaml.scanner import ScannerError
 from pathlib import Path
-from typing import List
 
 
 # returns the root of this repo by running "cd ../.." from this __file__ on
@@ -67,7 +66,7 @@ def validate_file_paths(paths: list):
         raise (e)
 
 
-def get_parent_dir(path: str) -> str:
+def get_parent_dir(path: str) -> Path:
     return Path(path).parent
 
 
@@ -85,6 +84,7 @@ def auto_create_dir(path: str) -> bool:
             print(f"OSError {path} could not be created...")
             return False
     return True
+
 
 def load_config(cfg_file):
     try:

--- a/dane_workflows/util/dane_util.py
+++ b/dane_workflows/util/dane_util.py
@@ -88,7 +88,9 @@ class DANEHandler:
         self.DANE_ES_QUERY_TIMEOUT = config["DANE_ES_QUERY_TIMEOUT"]
 
     def _get_batch_file_name(self, proc_batch_id: int) -> str:
-        fn = os.path.join(self.STATUS_DIR, f"{self._get_proc_batch_name(proc_batch_id)}.json")
+        fn = os.path.join(
+            self.STATUS_DIR, f"{self._get_proc_batch_name(proc_batch_id)}.json"
+        )
         self.logger.debug(f"{proc_batch_id} --> filename: {fn}")
         return fn
 
@@ -97,7 +99,9 @@ class DANEHandler:
         try:
             return json.load(open(self._get_batch_file_name(proc_batch_id)))
         except Exception:
-            self.logger.exception(f"Could not load {self._get_proc_batch_name(proc_batch_id)}.json")
+            self.logger.exception(
+                f"Could not load {self._get_proc_batch_name(proc_batch_id)}.json"
+            )
             return None
 
     # use to feed _add_tasks_to_batch()
@@ -132,7 +136,9 @@ class DANEHandler:
                     {
                         "query_string": {
                             "default_field": "creator.id",
-                            "query": '"{}"'.format(self._get_proc_batch_name(proc_batch_id)),
+                            "query": '"{}"'.format(
+                                self._get_proc_batch_name(proc_batch_id)
+                            ),
                         }
                     }
                 ]
@@ -205,7 +211,9 @@ class DANEHandler:
         else:
             for hit in result["hits"]["hits"]:
                 all_tasks.append(self._to_task(hit))
-            self.logger.debug(f"Done fetching all tasks for batch {self._get_proc_batch_name(proc_batch_id)}")
+            self.logger.debug(
+                f"Done fetching all tasks for batch {self._get_proc_batch_name(proc_batch_id)}"
+            )
             return self.get_tasks_of_batch(
                 proc_batch_id, all_tasks, offset + size, size
             )
@@ -229,7 +237,9 @@ class DANEHandler:
         else:
             for hit in result["hits"]["hits"]:
                 all_results.append(self._to_result(hit))
-            self.logger.debug(f"Done fetching all tasks for batch {self._get_proc_batch_name(proc_batch_id)}")
+            self.logger.debug(
+                f"Done fetching all tasks for batch {self._get_proc_batch_name(proc_batch_id)}"
+            )
             return self.get_results_of_batch(
                 proc_batch_id, all_results, offset + size, size
             )
@@ -544,12 +554,13 @@ class DANEHandler:
                     "url": sr.target_url,
                     "type": "Video",
                 },
-                {"id": self._get_proc_batch_name(sr.proc_batch_id), "type": "Organization"},
+                {
+                    "id": self._get_proc_batch_name(sr.proc_batch_id),
+                    "type": "Organization",
+                },
             ).to_json()
             for sr in status_rows
         ]
-    
+
     def _get_proc_batch_name(self, proc_batch_id):
         return f"{self.BATCH_PREFIX}_{proc_batch_id}"
-
-

--- a/dane_workflows/util/dane_util.py
+++ b/dane_workflows/util/dane_util.py
@@ -31,10 +31,26 @@ class TaskType(Enum):
 
 @unique
 class TaskState(Enum):
-    QUEUED = "102"  # means the task is queued (waiting for a worker to be freed up)
-    CREATED = "201"  # means the task was just created (before being queued)
-    SUCCESS = "200"  # means the task was successfully finished
-    ERROR = "500"  # means the task failed
+    QUEUED = "102"  # Task has been sent to a queue, it might be being worked on or held in queue.
+    SUCCESS = "200"  # Task completed successfully.
+    CREATED = "201"  # Task is registered, but has not been acted upon.
+    TASK_RESET = "205"  # Task reset state, typically after manual intervention
+    BAD_REQUEST = (
+        "400"  # Malformed request, typically the document or task description.
+    )
+    ACCESS_DENIED = "403"  # Access denied to underlying source material.
+    NOT_FOUND = "404"  # Underlying source material not found.
+    UNFINISHED_DEPENDENCY = "412"  # Task has a dependency which has not completed yet.
+    NO_ROUTE_TO_QUEUE = (
+        "422"  # If a task cannot be routed to a queue, this state is returned.
+    )
+    ERROR = (
+        "500"  # Error occurred during processing, details should be given in message.
+    )
+    ERROR_INVALID_INPUT = "502"  # Worker received invalid or partial input.
+    ERROR_PROXY = (
+        "503"  # Worker received an error response from a remote service it depends on.
+    )
 
 
 @dataclass

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,1 +1,0 @@
-folder for logs

--- a/main.py
+++ b/main.py
@@ -1,23 +1,19 @@
-import argparse
-import sys
-from dane_workflows.util.base_util import load_config
+from dane_workflows.util.base_util import extract_exec_params
 from dane_workflows.runner import construct_task_scheduler
 
-# test a full workflow
-if __name__ == "__main__":
-    # first determine which config file to use
-    parser = argparse.ArgumentParser(
-        description="dane-workflows default start-up script"
-    )
-    parser.add_argument("--cfg", action="store", dest="cfg", default="config.yml")
-    args = parser.parse_args()
-    print(f"Going to load the following config: {args.cfg}")
+"""
+Example main execution script for your (DANE) workflow:
 
-    # now go ahead and load the config
-    config = load_config(args.cfg)
-    if config is None:
-        print(f"Not a valid file path or config file {args.cfg}")
-        sys.exit()
+By defualt the following CMD line params are supported:
+* --cfg=./path_to_your/config.yml (default="config.yml")
+* --opt=anything-you-like (default=None)
+"""
+if __name__ == "__main__":
+    config, cmd_args = extract_exec_params()
+
+    # insert custom behaviour e.g. before running the workflow
+    if cmd_args.opt == "anything-you-like":
+        print("Well I never!")
 
     # obtain the runner, i.e. TaskScheduler
     runner = construct_task_scheduler(config)

--- a/main.py
+++ b/main.py
@@ -9,14 +9,14 @@ By defualt the following CMD line params are supported:
 * --opt=anything-you-like (default=None)
 """
 if __name__ == "__main__":
-    config, cmd_args = extract_exec_params()
+    config, cmd_args, logger = extract_exec_params()
 
     # insert custom behaviour e.g. before running the workflow
     if cmd_args.opt == "anything-you-like":
-        print("Well I never!")
+        logger.info("Well I never!")
 
     # obtain the runner, i.e. TaskScheduler
     runner = construct_task_scheduler(config)
     runner.run()
 
-    print("All done")
+    logger.info("All done")

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 from pathlib import Path
-from dane_workflows.util.base_util import load_config, import_module, init_data_dirs
+from dane_workflows.util.base_util import load_config, import_module
 from dane_workflows.task_scheduler import TaskScheduler
 
 # test a full workflow
@@ -20,6 +20,7 @@ if __name__ == "__main__":
         print(f"Not a valid file path or config file {args.cfg}")
         sys.exit()
 
+    """ TODO Move auto creation of dirs to _validate_config functions of each component
     dp_conf = config["DATA_PROVIDER"]["CONFIG"]
     pe_conf = config["PROC_ENV"]["CONFIG"] if "CONFIG" in config["PROC_ENV"] else None
     sh_conf = (
@@ -41,6 +42,7 @@ if __name__ == "__main__":
             "Could not create all the necessary data dirs to start-up this workflow, quitting"
         )
         sys.exit()
+    """
 
     ts = TaskScheduler(
         config,

--- a/main.py
+++ b/main.py
@@ -1,35 +1,8 @@
 import argparse
-import os
 import sys
 from pathlib import Path
-from typing import List
-from dane_workflows.util.base_util import load_config
+from dane_workflows.util.base_util import load_config, import_module, init_data_dirs
 from dane_workflows.task_scheduler import TaskScheduler
-
-
-def __init_data_dirs(data_dirs: List[str]) -> bool:
-    print("Checking if DATA_DIR exists")
-    for path in data_dirs:
-        if not os.path.exists(path):
-            print(f"path: '{path}' does not exist, creating it...")
-            try:
-                os.makedirs(path)
-            except OSError:
-                print(f"OSError {path} could not be created...")
-                return False
-    return True
-
-
-def __import_module(module_path: str):
-    tmp = module_path.split(".")
-    if len(tmp) != 3:
-        print(f"Malconfigured module path: {module_path}")
-        sys.exit()
-    module = getattr(__import__(tmp[0]), tmp[1])
-    workflow_class = getattr(module, tmp[2])
-    # globals()[tmp[2]] = workflow_class
-    return workflow_class
-
 
 # test a full workflow
 if __name__ == "__main__":
@@ -63,7 +36,7 @@ if __name__ == "__main__":
         data_dirs.append(pe_conf["DANE_STATUS_DIR"])
 
     # make sure they all exist before continuing
-    if not __init_data_dirs(data_dirs):
+    if not init_data_dirs(data_dirs):
         print(
             "Could not create all the necessary data dirs to start-up this workflow, quitting"
         )
@@ -71,11 +44,11 @@ if __name__ == "__main__":
 
     ts = TaskScheduler(
         config,
-        __import_module(config["STATUS_HANDLER"]["TYPE"]),
-        __import_module(config["DATA_PROVIDER"]["TYPE"]),
-        __import_module(config["PROC_ENV"]["TYPE"]),
-        __import_module(config["EXPORTER"]["TYPE"]),
-        __import_module(config["STATUS_MONITOR"]["TYPE"]),
+        import_module(config["STATUS_HANDLER"]["TYPE"]),
+        import_module(config["DATA_PROVIDER"]["TYPE"]),
+        import_module(config["PROC_ENV"]["TYPE"]),
+        import_module(config["EXPORTER"]["TYPE"]),
+        import_module(config["STATUS_MONITOR"]["TYPE"]),
     )
 
     ts.run()

--- a/main.py
+++ b/main.py
@@ -1,15 +1,33 @@
-from dane_workflows.util.base_util import extract_exec_params
+from dane_workflows.util.base_util import extract_exec_params, LOG_FORMAT
 from dane_workflows.runner import construct_task_scheduler
+import logging
+import sys
 
 """
 Example main execution script for your (DANE) workflow:
 
 By defualt the following CMD line params are supported:
 * --cfg=./path_to_your/config.yml (default="config.yml")
+* --log=DEBUG|INFO|WARNING|ERROR|CRITICAL
 * --opt=anything-you-like (default=None)
 """
+
+# initialises the root logger
+logging.basicConfig(
+    level=logging.DEBUG,
+    stream=sys.stdout,  # configure a stream handler only for now (single handler)
+    format=LOG_FORMAT,
+)
+logger = logging.getLogger()
+
 if __name__ == "__main__":
-    config, cmd_args, logger = extract_exec_params()
+    logger.info("Let's go people")
+    config, cmd_args = extract_exec_params()
+
+    # setting the loglevel
+    log_level = cmd_args.loglevel.upper()
+    logger.info(f"Setting the log level to: {log_level}")
+    logger.setLevel(log_level)
 
     # insert custom behaviour e.g. before running the workflow
     if cmd_args.opt == "anything-you-like":

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from typing import List
 from dane_workflows.util.base_util import load_config
 from dane_workflows.task_scheduler import TaskScheduler
 
+
 def __init_data_dirs(data_dirs: List[str]) -> bool:
     print("Checking if DATA_DIR exists")
     for path in data_dirs:
@@ -18,6 +19,7 @@ def __init_data_dirs(data_dirs: List[str]) -> bool:
                 return False
     return True
 
+
 def __import_module(module_path: str):
     tmp = module_path.split(".")
     if len(tmp) != 3:
@@ -28,10 +30,13 @@ def __import_module(module_path: str):
     # globals()[tmp[2]] = workflow_class
     return workflow_class
 
+
 # test a full workflow
 if __name__ == "__main__":
-     # first determine which config file to use
-    parser = argparse.ArgumentParser(description="dane-workflows default start-up script")
+    # first determine which config file to use
+    parser = argparse.ArgumentParser(
+        description="dane-workflows default start-up script"
+    )
     parser.add_argument("--cfg", action="store", dest="cfg", default="config.yml")
     args = parser.parse_args()
     print(f"Going to load the following config: {args.cfg}")
@@ -70,7 +75,7 @@ if __name__ == "__main__":
         __import_module(config["DATA_PROVIDER"]["TYPE"]),
         __import_module(config["PROC_ENV"]["TYPE"]),
         __import_module(config["EXPORTER"]["TYPE"]),
-        __import_module(config["STATUS_MONITOR"]["TYPE"])
+        __import_module(config["STATUS_MONITOR"]["TYPE"]),
     )
 
     ts.run()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,7 @@
 import argparse
 import sys
-from pathlib import Path
-from dane_workflows.util.base_util import load_config, import_module
-from dane_workflows.task_scheduler import TaskScheduler
+from dane_workflows.util.base_util import load_config
+from dane_workflows.runner import construct_task_scheduler
 
 # test a full workflow
 if __name__ == "__main__":
@@ -20,39 +19,8 @@ if __name__ == "__main__":
         print(f"Not a valid file path or config file {args.cfg}")
         sys.exit()
 
-    """ TODO Move auto creation of dirs to _validate_config functions of each component
-    dp_conf = config["DATA_PROVIDER"]["CONFIG"]
-    pe_conf = config["PROC_ENV"]["CONFIG"] if "CONFIG" in config["PROC_ENV"] else None
-    sh_conf = (
-        config["STATUS_HANDLER"]["CONFIG"]
-        if "CONFIG" in config["STATUS_HANDLER"]
-        else None
-    )
-
-    # assemble all data dirs from the config.yml
-    data_dirs = [dp_conf["DATA_DIR"]] if "DATA_DIR" in dp_conf else []
-    if sh_conf and "DB_FILE" in sh_conf:
-        data_dirs.append(Path(sh_conf["DB_FILE"]).parent)
-    if pe_conf and "DANE_STATUS_DIR" in pe_conf:
-        data_dirs.append(pe_conf["DANE_STATUS_DIR"])
-
-    # make sure they all exist before continuing
-    if not init_data_dirs(data_dirs):
-        print(
-            "Could not create all the necessary data dirs to start-up this workflow, quitting"
-        )
-        sys.exit()
-    """
-
-    ts = TaskScheduler(
-        config,
-        import_module(config["STATUS_HANDLER"]["TYPE"]),
-        import_module(config["DATA_PROVIDER"]["TYPE"]),
-        import_module(config["PROC_ENV"]["TYPE"]),
-        import_module(config["EXPORTER"]["TYPE"]),
-        import_module(config["STATUS_MONITOR"]["TYPE"]),
-    )
-
-    ts.run()
+    # obtain the runner, i.e. TaskScheduler
+    runner = construct_task_scheduler(config)
+    runner.run()
 
     print("All done")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dane_workflows"
-version = "0.2.1"
+version = "0.2.2"
 description = "Library providing batch upload & monitoring for (DANE) processing environments"
 readme = "README.md"
 authors = [

--- a/tests/unit_tests/base_util_test.py
+++ b/tests/unit_tests/base_util_test.py
@@ -1,6 +1,4 @@
-import logging
-from logging.handlers import TimedRotatingFileHandler
-from mockito import when, ANY, verify
+from mockito import when, verify
 import os
 import sys
 import pytest
@@ -13,7 +11,6 @@ from dane_workflows.util.base_util import (
     validate_parent_dirs,
     validate_file_paths,
     load_config_or_die,
-    init_logger,
 )
 
 
@@ -177,20 +174,3 @@ def test_load_config_or_die(path_to_file, expect_file):
         else:
             assert not load_config_or_die(path_to_file)
             verify(sys, times=1).exit()
-
-
-def test_init_logger(config):
-
-    with when(os.path).exists(ANY).thenReturn(True):
-        logger = init_logger(config)
-
-        assert logger
-        assert len(logger.handlers) == 2
-        assert isinstance(logger.handlers[0], TimedRotatingFileHandler)
-        assert (
-            logging.getLevelName(logger.handlers[0].level) == config["LOGGING"]["LEVEL"]
-        )
-        assert isinstance(logger.handlers[1], logging.StreamHandler)
-        assert (
-            logging.getLevelName(logger.handlers[1].level) == config["LOGGING"]["LEVEL"]
-        )

--- a/tests/unit_tests/base_util_test.py
+++ b/tests/unit_tests/base_util_test.py
@@ -1,7 +1,8 @@
 import logging
 from logging.handlers import TimedRotatingFileHandler
-from mockito import when, ANY
+from mockito import when, ANY, verify
 import os
+import sys
 import pytest
 from dane_workflows.util.base_util import (
     get_repo_root,
@@ -11,7 +12,7 @@ from dane_workflows.util.base_util import (
     check_log_level,
     validate_parent_dirs,
     validate_file_paths,
-    load_config,
+    load_config_or_die,
     init_logger,
 )
 
@@ -169,11 +170,13 @@ def test_validate_file_paths(paths, should_pass_test):
         (__file__, False),
     ],
 )
-def test_load_config(path_to_file, expect_file):
-    if expect_file:
-        assert load_config(path_to_file)
-    else:
-        assert not load_config(path_to_file)
+def test_load_config_or_die(path_to_file, expect_file):
+    with when(sys).exit().thenReturn():
+        if expect_file:
+            assert load_config_or_die(path_to_file)
+        else:
+            assert not load_config_or_die(path_to_file)
+            verify(sys, times=1).exit()
 
 
 def test_init_logger(config):

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -26,7 +26,6 @@ def config():
 @pytest.fixture
 def slack_monitor_config():
     config = load_config(relative_from_file(__file__, "../../config-unit-test.yml"))
-    config["STATUS_MONITOR"]["TYPE"] = "SlackStatusMonitor"
     config["STATUS_MONITOR"]["CONFIG"] = {}
     config["STATUS_MONITOR"]["CONFIG"]["TOKEN"] = "some_random_token"
     config["STATUS_MONITOR"]["CONFIG"]["CHANNEL"] = "a_channel"

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from dane_workflows.util.base_util import load_config, relative_from_file
+from dane_workflows.util.base_util import load_config_or_die, relative_from_file
 
 
 WORKFLOW_ROOT_DIR = relative_from_file(__file__, os.sep.join(["..", ".."]))
@@ -8,7 +8,9 @@ WORKFLOW_ROOT_DIR = relative_from_file(__file__, os.sep.join(["..", ".."]))
 
 @pytest.fixture()
 def config():
-    config = load_config(relative_from_file(__file__, "../../config-unit-test.yml"))
+    config = load_config_or_die(
+        relative_from_file(__file__, "../../config-unit-test.yml")
+    )
 
     # adjust paths as these are relative
     if (
@@ -25,7 +27,9 @@ def config():
 
 @pytest.fixture
 def slack_monitor_config():
-    config = load_config(relative_from_file(__file__, "../../config-unit-test.yml"))
+    config = load_config_or_die(
+        relative_from_file(__file__, "../../config-unit-test.yml")
+    )
     config["STATUS_MONITOR"]["CONFIG"] = {}
     config["STATUS_MONITOR"]["CONFIG"]["TOKEN"] = "some_random_token"
     config["STATUS_MONITOR"]["CONFIG"]["CHANNEL"] = "a_channel"

--- a/tests/unit_tests/data_processing_test.py
+++ b/tests/unit_tests/data_processing_test.py
@@ -1,10 +1,9 @@
 from mockito import unstub, when, ANY, verify, spy2
 import pytest
 import sys
-import dane_workflows.util.base_util
 from dane_workflows.data_processing import ExampleDataProcessingEnvironment
 from dane_workflows.status import ExampleStatusHandler, ProcessingStatus, ErrorCode
-from test_util import new_batch, LoggerMock
+from test_util import new_batch
 
 
 @pytest.mark.parametrize(
@@ -18,12 +17,9 @@ from test_util import new_batch, LoggerMock
 def test_register_batch(
     config, proc_batch_id, proc_batch, register_success, status_persisted
 ):
-    logger_mock = LoggerMock()
     status_handler = ExampleStatusHandler(config)
     dpe = ExampleDataProcessingEnvironment(config, status_handler)
-    with when(dane_workflows.util.base_util).init_logger(config).thenReturn(
-        logger_mock
-    ), when(  # mock success/failure by returning empty status_rows or ones with proper status_rows
+    with when(  # mock success/failure by returning empty status_rows or ones with proper status_rows
         dpe
     )._register_batch(
         proc_batch_id, proc_batch
@@ -58,20 +54,13 @@ def test_register_batch(
     [(0, False, True), (0, True, True), (0, True, False)],
 )
 def test_process_batch(config, proc_batch_id, proc_env_error, status_persisted):
-    logger_mock = LoggerMock()
     status_handler = ExampleStatusHandler(config)
     dpe = ExampleDataProcessingEnvironment(config, status_handler)
-    with when(dane_workflows.util.base_util).init_logger(config).thenReturn(
-        logger_mock
-    ), when(dpe)._set_by_processing_response(proc_batch_id, ANY).thenReturn(
+    with when(dpe)._set_by_processing_response(proc_batch_id, ANY).thenReturn(
         new_batch(0, ProcessingStatus.ERROR, ErrorCode.BATCH_PROCESSING_NOT_STARTED)
         if proc_env_error
         else new_batch(0, ProcessingStatus.PROCESSING)
-    ), when(
-        status_handler
-    ).persist(
-        ANY
-    ).thenReturn(
+    ), when(status_handler).persist(ANY).thenReturn(
         status_persisted
     ), when(  # mock, so it never actually quits the program
         sys

--- a/tests/unit_tests/status_monitor_test.py
+++ b/tests/unit_tests/status_monitor_test.py
@@ -232,7 +232,6 @@ def test_validate_config(
     config, token, channel, workflow_name, include_extra_info, expect_error
 ):
     config_to_validate = config
-    config_to_validate["STATUS_MONITOR"]["TYPE"] = "SlackStatusMonitor"
     config_to_validate["STATUS_MONITOR"]["CONFIG"] = {}
     if token:
         config_to_validate["STATUS_MONITOR"]["CONFIG"]["TOKEN"] = token
@@ -300,7 +299,6 @@ def test_format_status_info(slack_monitor_config, status_info: dict, expected_ou
 )
 def test__send_status(config, formatted_error_report):
     status_handler = ExampleStatusHandler(config)
-    config["STATUS_MONITOR"]["TYPE"] = "SlackStatusMonitor"
     config["STATUS_MONITOR"]["CONFIG"] = {
         "TOKEN": "a token",
         "CHANNEL": "a channel",
@@ -331,7 +329,6 @@ def test__send_status(config, formatted_error_report):
 @pytest.mark.parametrize("include_extra_info", [False, True])
 def test_monitor_status(config, include_extra_info):
     status_handler = ExampleStatusHandler(config)
-    config["STATUS_MONITOR"]["TYPE"] = "SlackStatusMonitor"
     config["STATUS_MONITOR"]["CONFIG"] = {
         "TOKEN": "a token",
         "CHANNEL": "a channel",

--- a/tests/unit_tests/status_test.py
+++ b/tests/unit_tests/status_test.py
@@ -206,7 +206,6 @@ def test_get_status_counts_for_proc_batch_id(
     config, statuses, proc_batch_ids, expected_status_counts
 ):
     try:
-        config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
 
         # use a test folder to store the database so production database is not affected
         if os.getcwd().endswith("unit_tests"):
@@ -320,7 +319,6 @@ def test_get_error_code_counts_for_proc_batch_id(
     config, error_codes, proc_batch_ids, expected_error_code_counts
 ):
     try:
-        config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
 
         # use a test folder to store the database so production database is not affected
         if os.getcwd().endswith("unit_tests"):
@@ -434,7 +432,6 @@ def test_get_status_counts_for_source_batch_id(
     config, statuses, source_batch_ids, expected_status_counts
 ):
     try:
-        config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
 
         # use a test folder to store the database so production database is not affected
         if os.getcwd().endswith("unit_tests"):
@@ -547,7 +544,6 @@ def test_get_status_counts_for_source_batch_id(
 def test_get_error_code_counts_for_source_batch_id(
     config, error_codes, source_batch_ids, expected_error_code_counts
 ):
-    config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
 
     # use a test folder to store the database so production database is not affected
     if os.getcwd().endswith("unit_tests"):
@@ -650,8 +646,6 @@ def test_get_error_code_counts_for_source_batch_id(
 def test_get_completed_semantic_source_batch_ids(
     config, statuses, semantic_source_batch_ids, expected_complete, expected_incomplete
 ):
-
-    config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
 
     # use a test folder to store the database so production database is not affected
     if os.getcwd().endswith("unit_tests"):
@@ -784,8 +778,6 @@ def test_get_running_statuses_and_completed_statuses():
 )
 def test_get_status_counts(config, statuses, source_batch_ids, expected_status_counts):
 
-    config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
-
     # use a test folder to store the database so production database is not affected
     if os.getcwd().endswith("unit_tests"):
         config["STATUS_HANDLER"]["CONFIG"] = {
@@ -907,8 +899,6 @@ def test_get_error_code_counts(
     config, error_codes, source_batch_ids, expected_error_code_counts
 ):
 
-    config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
-
     # use a test folder to store the database so production database is not affected
     if os.getcwd().endswith("unit_tests"):
         config["STATUS_HANDLER"]["CONFIG"] = {
@@ -1012,8 +1002,6 @@ def test_get_error_code_counts(
 def test_get_status_counts_per_extra_info(
     config, statuses, extra_info_values, expected_status_counts
 ):
-
-    config["STATUS_HANDLER"]["TYPE"] = "SQLiteStatusHandler"
 
     # use a test folder to store the database so production database is not affected
     if os.getcwd().endswith("unit_tests"):

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -14,6 +14,9 @@ class LoggerMock(object):
     def error(self, info_string):
         pass
 
+    def critical(self, info_string):
+        pass
+
 
 def new_batch(
     source_batch_id: int,


### PR DESCRIPTION
now it's possible to configure different dane workflow components (e.g. a DataProvider or Exporter) without needing to adapt the main.py of a workflow.

TODO:
- [ ] write unit tests for the new runner module

**Test plan**

- [x] pull this branch
- [x] check out the `config-example.yml` to see how to configure the `TYPE` settings now (and apply to your own `config.yml`)
- [x] check out the `import_dane_workflow_module` function that is now part of the `base_util`
- [x] check out the `main.py` and see how the `import_dane_workflow_module` is used to feed the `TaskScheduler`
- [x] check out the `extract_exec_params` function that is now part of the `base_util`
- [x] check out how this function is used in `main.py`
- [ ] run `main.py` and see if it works normally
- [x] check out the testplan in the this [PR](https://github.com/beeldengeluid/dane-beng-workflows/pull/71) 