### PR TITLE
fix for issue 11

### DIFF
--- a/dane_workflows/util/dane_util.py
+++ b/dane_workflows/util/dane_util.py
@@ -184,6 +184,8 @@ class DANEHandler:
             return query
         return tasks_query
 
+    # FIXME: in case the underlying tasks mentioned: "task already assigned", the results will
+    # NOT be found this way
     def _generate_results_of_batch_query(self, proc_batch_id, offset, size):
         logger.debug("Entering function")
         tasks_of_batch_query = self._generate_tasks_of_batch_query(
@@ -256,7 +258,7 @@ class DANEHandler:
             for hit in result["hits"]["hits"]:
                 all_results.append(self._to_result(hit))
             logger.debug(
-                f"Done fetching all tasks for batch {self._get_proc_batch_name(proc_batch_id)}"
+                f"Done fetching all results for batch {self._get_proc_batch_name(proc_batch_id)}"
             )
             return self.get_results_of_batch(
                 proc_batch_id, all_results, offset + size, size


### PR DESCRIPTION
related issue: https://github.com/beeldengeluid/dane-workflows/issues/11

**Testplan**
- [ ] pull this code and make sure to incorporate it into your local daan_asr_aws workflow. 
- [ ] configure the ExampleDataProvider (with the 2 files that should work)
- [ ] configure the DANEEnvironment with a new `DANE_BATCH_PREFIX`
- [ ] make sure the workflow completes successfully (ASR is generated)
- [ ] throw away the status DB and rerun it
- [ ] the workflows should run successfully again (no keyerror)
- [ ] search the log for WARNINGs with "Task ... already assigned to document" (should be there after the second run)

