### PR TITLE
Slack status monitor improvements

### DIFF
--- a/config-unit-test.yml
+++ b/config-unit-test.yml
@@ -13,6 +13,11 @@ PROC_ENV:
   TYPE: dane_workflows.data_processing.ExampleDataProcessingEnvironment
 EXPORTER:
   TYPE: dane_workflows.exporter.ExampleExporter
+  CONFIG:
+    DAAN_ES_HOST: "dummy_es_host"
+    DAAN_ES_PORT: 0000
+    DAAN_ES_INPUT_INDEX: "dummy_es_input_index"
+    DAAN_ES_OUTPUT_INDEX: "dummy_es_output_index"
 STATUS_MONITOR:  # optional, for monitoring 
   TYPE: dane_workflows.status_monitor.ExampleStatusMonitor
   CONFIG:

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -372,8 +372,12 @@ class DANEEnvironment(DataProcessingEnvironment):
 
     def get_pretty_processing_conf_vars(self):
         pretty_config_dict = {}
-        pretty_config_dict["PROC_ENV...DANE_HOST"] = f'{self.config["DANE_HOST"]}/manage'
-        pretty_config_dict["PROC_ENV...DANE_ES_HOST"] = f'http://{self.config["DANE_ES_HOST"]}:{self.config["DANE_ES_PORT"]}/{self.config["DANE_ES_INDEX"]}'
+        pretty_config_dict[
+            "PROC_ENV...DANE_HOST"
+        ] = f'{self.config["DANE_HOST"]}/manage'
+        pretty_config_dict[
+            "PROC_ENV...DANE_ES_HOST"
+        ] = f'http://{self.config["DANE_ES_HOST"]}:{self.config["DANE_ES_PORT"]}/{self.config["DANE_ES_INDEX"]}'
         return pretty_config_dict
 
 

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -124,6 +124,9 @@ class DataProcessingEnvironment(ABC):
         self.status_handler.persist_or_die(status_rows)
         return results
 
+    def get_pretty_processing_conf_vars(self) -> dict:
+        return self.config
+
     @abstractmethod
     def fetch_result_of_target_id(self, target_id: str) -> Optional[ProcessingResult]:
         raise NotImplementedError(
@@ -220,6 +223,7 @@ class DANEEnvironment(DataProcessingEnvironment):
             ), f"DANE_STATUS_DIR: {self.config['DANE_STATUS_DIR']} auto creation failed"
         except AssertionError as e:
             logger.error(f"Configuration error: {str(e)}")
+            logger.error(f"config:{self.config}")
             return False
 
         return True
@@ -365,6 +369,12 @@ class DANEEnvironment(DataProcessingEnvironment):
                 else ProcessingStatus.ERROR
             )
         return status_rows
+
+    def get_pretty_processing_conf_vars(self):
+        pretty_config_dict = {}
+        pretty_config_dict["PROC_ENV...DANE_HOST"] = f'{self.config["DANE_HOST"]}/manage'
+        pretty_config_dict["PROC_ENV...DANE_ES_HOST"] = f'http://{self.config["DANE_ES_HOST"]}:{self.config["DANE_ES_PORT"]}/{self.config["DANE_ES_INDEX"]}'
+        return pretty_config_dict
 
 
 class ExampleDataProcessingEnvironment(DataProcessingEnvironment):

--- a/dane_workflows/data_processing.py
+++ b/dane_workflows/data_processing.py
@@ -124,7 +124,7 @@ class DataProcessingEnvironment(ABC):
         self.status_handler.persist_or_die(status_rows)
         return results
 
-    def get_pretty_processing_conf_vars(self) -> dict:
+    def get_pretty_config(self) -> dict:
         return self.config
 
     @abstractmethod
@@ -370,15 +370,13 @@ class DANEEnvironment(DataProcessingEnvironment):
             )
         return status_rows
 
-    def get_pretty_processing_conf_vars(self):
-        pretty_config_dict = {}
-        pretty_config_dict[
-            "PROC_ENV...DANE_HOST"
-        ] = f'{self.config["DANE_HOST"]}/manage'
-        pretty_config_dict[
+    def get_pretty_config(self) -> dict:
+        pretty_conf = {}
+        pretty_conf["PROC_ENV...DANE_HOST"] = f'{self.config["DANE_HOST"]}/manage'
+        pretty_conf[
             "PROC_ENV...DANE_ES_HOST"
         ] = f'http://{self.config["DANE_ES_HOST"]}:{self.config["DANE_ES_PORT"]}/{self.config["DANE_ES_INDEX"]}'
-        return pretty_config_dict
+        return pretty_conf
 
 
 class ExampleDataProcessingEnvironment(DataProcessingEnvironment):

--- a/dane_workflows/exporter.py
+++ b/dane_workflows/exporter.py
@@ -63,6 +63,10 @@ class ExampleExporter(Exporter):
 
     def get_pretty_export_conf_vars(self):
         pretty_processing_vars = {}
-        pretty_processing_vars["EXPORTER...DAAN_ES_INPUT_INDEX"] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_INPUT_INDEX"]}'
-        pretty_processing_vars["EXPORTER...DAAN_ES_OUTPUT_INDEX"] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_OUTPUT_INDEX"]}'
+        pretty_processing_vars[
+            "EXPORTER...DAAN_ES_INPUT_INDEX"
+        ] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_INPUT_INDEX"]}'
+        pretty_processing_vars[
+            "EXPORTER...DAAN_ES_OUTPUT_INDEX"
+        ] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_OUTPUT_INDEX"]}'
         return pretty_processing_vars

--- a/dane_workflows/exporter.py
+++ b/dane_workflows/exporter.py
@@ -27,7 +27,7 @@ class Exporter(ABC):
 
         self.status_handler = status_handler
 
-    def get_pretty_export_conf_vars(self):
+    def get_pretty_config(self) -> dict:
         return self.config
 
     @abstractmethod
@@ -61,12 +61,12 @@ class ExampleExporter(Exporter):
         )
         return True
 
-    def get_pretty_export_conf_vars(self):
-        pretty_processing_vars = {}
-        pretty_processing_vars[
+    def get_pretty_config(self) -> dict:
+        pretty_conf = {}
+        pretty_conf[
             "EXPORTER...DAAN_ES_INPUT_INDEX"
         ] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_INPUT_INDEX"]}'
-        pretty_processing_vars[
+        pretty_conf[
             "EXPORTER...DAAN_ES_OUTPUT_INDEX"
         ] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_OUTPUT_INDEX"]}'
-        return pretty_processing_vars
+        return pretty_conf

--- a/dane_workflows/exporter.py
+++ b/dane_workflows/exporter.py
@@ -27,6 +27,9 @@ class Exporter(ABC):
 
         self.status_handler = status_handler
 
+    def get_pretty_export_conf_vars(self):
+        return self.config
+
     @abstractmethod
     def _validate_config(self) -> bool:
         raise NotImplementedError("Implement to validate the config")
@@ -57,3 +60,9 @@ class ExampleExporter(Exporter):
             )
         )
         return True
+
+    def get_pretty_export_conf_vars(self):
+        pretty_processing_vars = {}
+        pretty_processing_vars["EXPORTER...DAAN_ES_INPUT_INDEX"] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_INPUT_INDEX"]}'
+        pretty_processing_vars["EXPORTER...DAAN_ES_OUTPUT_INDEX"] = f'http://{self.config["DAAN_ES_HOST"]}:{self.config["DAAN_ES_PORT"]}/{self.config["DAAN_ES_OUTPUT_INDEX"]}'
+        return pretty_processing_vars

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -13,7 +13,10 @@ from dane_workflows.status import (
 from dane_workflows.util.base_util import check_setting, load_config_or_die
 from datetime import datetime
 
-from dane_workflows.data_processing import DataProcessingEnvironment, ExampleDataProcessingEnvironment
+from dane_workflows.data_processing import (
+    DataProcessingEnvironment,
+    ExampleDataProcessingEnvironment,
+)
 from dane_workflows.exporter import Exporter, ExampleExporter
 
 
@@ -21,7 +24,13 @@ logger = logging.getLogger(__name__)
 
 
 class StatusMonitor(ABC):
-    def __init__(self, config: dict, status_handler: StatusHandler, data_processing_env: DataProcessingEnvironment, exporter: Exporter):
+    def __init__(
+        self,
+        config: dict,
+        status_handler: StatusHandler,
+        data_processing_env: DataProcessingEnvironment,
+        exporter: Exporter,
+    ):
         self.status_handler = status_handler
         self.data_processing_env = data_processing_env
         self.exporter = exporter
@@ -42,10 +51,7 @@ class StatusMonitor(ABC):
 
         try:
             assert all(
-                [
-                    x in self.config
-                    for x in ["INCLUDE_EXTRA_INFO"]
-                ]
+                [x in self.config for x in ["INCLUDE_EXTRA_INFO"]]
             ), "StatusMonitor config misses required fields"
 
             assert check_setting(
@@ -156,7 +162,9 @@ class StatusMonitor(ABC):
         chosen method (implemented in _send_status())
         """
         status_info = self._check_status()
-        satus_report = self._get_detailed_status_report(include_extra_info=self.config["INCLUDE_EXTRA_INFO"])
+        satus_report = self._get_detailed_status_report(
+            include_extra_info=self.config["INCLUDE_EXTRA_INFO"]
+        )
         formatted_status_info = self._format_status_info(status_info)
         formatted_status_report = self._format_status_report(satus_report)
         self._send_status(formatted_status_info, formatted_status_report)
@@ -196,8 +204,16 @@ class StatusMonitor(ABC):
 
 
 class ExampleStatusMonitor(StatusMonitor):
-    def __init__(self, config: dict, status_handler: StatusHandler, data_processing_env: DataProcessingEnvironment, exporter: Exporter):
-        super(ExampleStatusMonitor, self).__init__(config, status_handler, data_processing_env, exporter)
+    def __init__(
+        self,
+        config: dict,
+        status_handler: StatusHandler,
+        data_processing_env: DataProcessingEnvironment,
+        exporter: Exporter,
+    ):
+        super(ExampleStatusMonitor, self).__init__(
+            config, status_handler, data_processing_env, exporter
+        )
 
     def _validate_config(self):
         return StatusMonitor._validate_config(self)  # no additional config needed
@@ -240,8 +256,16 @@ class ExampleStatusMonitor(StatusMonitor):
 
 
 class SlackStatusMonitor(StatusMonitor):
-    def __init__(self, config: dict, status_handler: StatusHandler, data_processing_env: DataProcessingEnvironment, exporter: Exporter):
-        super(SlackStatusMonitor, self).__init__(config, status_handler, data_processing_env, exporter)
+    def __init__(
+        self,
+        config: dict,
+        status_handler: StatusHandler,
+        data_processing_env: DataProcessingEnvironment,
+        exporter: Exporter,
+    ):
+        super(SlackStatusMonitor, self).__init__(
+            config, status_handler, data_processing_env, exporter
+        )
 
     def _validate_config(self):
         """Check that the config contains the necessary parameters for Slack"""
@@ -424,5 +448,7 @@ if __name__ == "__main__":
     status_handler = ExampleStatusHandler(config)
     data_processing_env = ExampleDataProcessingEnvironment(config, status_handler)
     exporter = ExampleExporter(config, status_handler)
-    status_monitor = SlackStatusMonitor(config, status_handler, data_processing_env, exporter)
+    status_monitor = SlackStatusMonitor(
+        config, status_handler, data_processing_env, exporter
+    )
     status_monitor._monitor_status()

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -42,14 +42,13 @@ class StatusMonitor(ABC):
             assert all(
                 [
                     x in self.config
-                    for x in ["TOKEN", "CHANNEL", "WORKFLOW_NAME","INCLUDE_EXTRA_INFO"]
+                    for x in ["INCLUDE_EXTRA_INFO"]
                 ]
             ), "StatusMonitor config misses required fields"
 
             assert check_setting(
                 self.config["INCLUDE_EXTRA_INFO"], bool
             ), "StatusMonitor.INCLUDE_EXTRA_INFO not a bool"
-
 
         except AssertionError as e:
             logger.error(f"Configuration error: {str(e)}")
@@ -334,7 +333,6 @@ class SlackStatusMonitor(StatusMonitor):
             fields.append({"type": "mrkdwn", "text": text})
         return {"type": "section", "fields": fields}
 
-    @staticmethod
     def _create_context_block(self):
         """Add a block of type context containing a mrkdwn field listing relevant values from config
         Args:
@@ -348,23 +346,23 @@ class SlackStatusMonitor(StatusMonitor):
         statusItems = {}
         if self.proc_env_conf["TYPE"] == "dane_workflows.data_processing.DANEEnvironment":
             statusItems["PROC_ENV...DANE_HOST"] = "{}/manage".format(
-                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_HOST"]
+                    self.proc_env_conf["CONFIG"]["DANE_HOST"]
                 )
             statusItems["PROC_ENV...DANE_ES_HOST"] = "http://{}:{}/{}".format(
-                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"],
-                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"],
-                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"],
+                    self.proc_env_conf["CONFIG"]["DANE_ES_HOST"],
+                    self.proc_env_conf["CONFIG"]["DANE_ES_PORT"],
+                    self.proc_env_conf["CONFIG"]["DANE_ES_INDEX"],
                 )
 
         statusItems["EXPORTER...DAAN_ES_INPUT_INDEX"] = "http://{}:{}/{}".format(
-                    self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
-                    self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
-                    self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_INPUT_INDEX"],
+                    self.export_conf["CONFIG"]["DAAN_ES_HOST"],
+                    self.export_conf["CONFIG"]["DAAN_ES_PORT"],
+                    self.export_conf["CONFIG"]["DAAN_ES_INPUT_INDEX"],
                 )
         statusItems["EXPORTER...DAAN_ES_OUTPUT_INDEX"] = "http://{}:{}/{}".format(
-                self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
-                self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
-                self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_OUTPUT_INDEX"],
+                self.export_conf["CONFIG"]["DAAN_ES_HOST"],
+                self.export_conf["CONFIG"]["DAAN_ES_PORT"],
+                self.export_conf["CONFIG"]["DAAN_ES_OUTPUT_INDEX"],
             )
         statusItems["Definitions"]: statusDefinitionsURL
 
@@ -394,7 +392,7 @@ class SlackStatusMonitor(StatusMonitor):
         slack_status_info_list.append(
             self._create_markdown_fields_section_block(status_info)
         )
-        slack_status_info_list.append(self._create_context_block(self.config))
+        slack_status_info_list.append(self._create_context_block())
 
         return slack_status_info_list
 

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -342,7 +342,7 @@ class SlackStatusMonitor(StatusMonitor):
         slack_client.chat_postMessage(
             channel=self.config["CHANNEL"],
             blocks=formatted_status,
-            icon_emoji=":ghost:",
+            icon_emoji=":female_elf:",
         )
 
         if formatted_error_report:  # only upload error file if has content

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -148,6 +148,16 @@ class StatusMonitor(ABC):
             ] = self.status_handler.get_status_counts_per_extra_info_value()
 
         return error_report
+    
+    def _monitor_status(self):
+        """Retrieves the status and error information and communicates this via the
+        chosen method (implemented in _send_status())
+        """
+        status_info = self._check_status()
+        error_report = self._get_detailed_status_report(include_extra_info=self.config["INCLUDE_EXTRA_INFO"])
+        formatted_status_info = self._format_status_info(status_info)
+        formatted_error_report = self._format_error_report(error_report)
+        self._send_status(formatted_status_info, formatted_error_report)
 
     @abstractmethod
     def _format_status_info(self, status_info: dict):
@@ -179,13 +189,6 @@ class StatusMonitor(ABC):
         - formatted_status - a string containing the formatted status information
         - formatted_error_report - Optional: a string containing the formatted error report
         Returns:
-        """
-        raise NotImplementedError("All StatusMonitors should implement this")
-
-    @abstractmethod
-    def monitor_status(self):
-        """Retrieves the status and error information and communicates this via the
-        chosen method (implemented in _send_status())
         """
         raise NotImplementedError("All StatusMonitors should implement this")
 
@@ -232,14 +235,6 @@ class ExampleStatusMonitor(StatusMonitor):
         logger.info(formatted_status)
         logger.info("DETAILED ERROR REPORT:")
         logger.info(formatted_error_report)
-
-    def monitor_status(self):
-        """Retrieves the status and error information and communicates this via the terminal"""
-        status_info = self._check_status()
-        error_report = self._get_detailed_status_report(status_info)
-        formatted_status_info = self._format_status_info(status_info)
-        formatted_error_report = self._format_error_report(error_report)
-        self._send_status(formatted_status_info, formatted_error_report)
 
 
 class SlackStatusMonitor(StatusMonitor):
@@ -431,15 +426,6 @@ class SlackStatusMonitor(StatusMonitor):
                 initial_comment="*Error file* (based on current status database)",
             )
 
-    def monitor_status(self):
-        """Retrieves the status and error information and communicates this via the terminal"""
-        status_info = self._check_status()
-        error_report = self._get_detailed_status_report(
-            include_extra_info=self.config["INCLUDE_EXTRA_INFO"]
-        )
-        formatted_status_info = self._format_status_info(status_info)
-        formatted_error_report = self._format_error_report(error_report)
-        self._send_status(formatted_status_info, formatted_error_report)
 
 
 if __name__ == "__main__":
@@ -452,4 +438,4 @@ if __name__ == "__main__":
     )  # TODO: how do we get this to work from within a workflow with the correct config?
     status_handler = ExampleStatusHandler(config)
     status_monitor = SlackStatusMonitor(config, status_handler)
-    status_monitor.monitor_status()
+    status_monitor._monitor_status()

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -397,3 +397,5 @@ if __name__ == "__main__":
     )  # TODO: how do we get this to work from within a workflow with the correct config?
     status_handler = ExampleStatusHandler(config)
     status_monitor = SlackStatusMonitor(config, status_handler)
+    status_monitor.monitor_status()
+    

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -342,7 +342,6 @@ class SlackStatusMonitor(StatusMonitor):
         slack_client.chat_postMessage(
             channel=self.config["CHANNEL"],
             blocks=formatted_status,
-            icon_emoji=":female_elf:",
         )
 
         if formatted_error_report:  # only upload error file if has content

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -40,7 +40,10 @@ class StatusMonitor(ABC):
 
         try:
             assert all(
-                [x in self.config for x in ["INCLUDE_EXTRA_INFO", "PROC_ENV", "EXPORTER"]]
+                [
+                    x in self.config
+                    for x in ["INCLUDE_EXTRA_INFO", "PROC_ENV", "EXPORTER"]
+                ]
             ), "StatusMonitor config misses required fields"
 
             assert check_setting(
@@ -56,11 +59,11 @@ class StatusMonitor(ABC):
     def _check_status(self):
         """Collects status information about the tasks stored in the status_handler and returns it in a dict
         Returns: dict with status information
-        
+
         "Last batch processed:" - processing batch ID of the last batch processed
         "Last batch processed :information_source: Status info:" - dict of statuses and their counts for the last batch processed
         "Last batch processed :warning: Error info:" - dict of error codes and their counts for the last batch processed
-        
+
         "Last src batch retrieved:" - source batch ID of the last batch retrieved from the data provider
         "Last src batch retrieved :information_source: Status info:" - dict of error codes and their counts for the last batch
         retrieved from the data provider
@@ -294,7 +297,7 @@ class SlackStatusMonitor(StatusMonitor):
         - returns the text block as expected by the Slack API
         """
         return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
-    
+
     @staticmethod
     def _create_markdown_fields_section_block(status_info: dict):
         """Add a block of type section containing a list of mrkdwn fields
@@ -312,12 +315,12 @@ class SlackStatusMonitor(StatusMonitor):
                 case int() as value:
                     text = f"*{key}:*\n{value}"
                 case {} as value:
-                    if 'error' in key.lower():
+                    if "error" in key.lower():
                         text = f"*{key}:*\nN/A :large_green_circle:"
                     else:
                         text = f"*{key}:*\nN/A"
                 case dict() as value:
-                    if 'error' in key.lower():
+                    if "error" in key.lower():
                         text = f"*{key}:*\n:red_circle:\n"
                     else:
                         text = f"*{key}:*\n"
@@ -327,15 +330,9 @@ class SlackStatusMonitor(StatusMonitor):
                     raise TypeError(
                         f"{type(value)} is of the wrong type or this type is not implemented"
                     )
-            fields.append({
-                "type": "mrkdwn",
-                "text": text
-            })
-        return  {
-            "type": "section",
-            "fields": fields
-        }
-    
+            fields.append({"type": "mrkdwn", "text": text})
+        return {"type": "section", "fields": fields}
+
     @staticmethod
     def _create_context_block(config):
         """Add a block of type context containing a mrkdwn field listing relevant values from config
@@ -344,30 +341,42 @@ class SlackStatusMonitor(StatusMonitor):
         Returns:
         - returns the context block as expected by the Slack API
         """
-        statusDefinitionsURL = 'https://beng.slack.com/files/T03P55HJ9/F042WDNGD5W?origin_team=T03P55HJ9'
+        statusDefinitionsURL = (
+            "https://beng.slack.com/files/T03P55HJ9/F042WDNGD5W?origin_team=T03P55HJ9"
+        )
         statusItems = {
             "PROC_ENV.CONFIG.DANE_HOST": config["PROC_ENV"]["CONFIG"]["DANE_HOST"],
-            "PROC_ENV.CONFIG.DANE_ES_HOST": config["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"],
-            "PROC_ENV.CONFIG.DANE_ES_PORT": config["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"],
-            "PROC_ENV.CONFIG.DANE_ES_INDEX": config["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"],
-            "EXPORTER.CONFIG.DAAN_ES_HOST": config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
-            "EXPORTER.CONFIG.DAAN_ES_PORT": config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
-            "EXPORTER.CONFIG.DAAN_ES_INPUT_INDEX": config["EXPORTER"]["CONFIG"]["DAAN_ES_INPUT_INDEX"],
-            "EXPORTER.CONFIG.DAAN_ES_OUTPUT_INDEX": config["EXPORTER"]["CONFIG"]["DAAN_ES_OUTPUT_INDEX"],
-            "Definitions": statusDefinitionsURL
+            "PROC_ENV.CONFIG.DANE_ES_HOST": config["PROC_ENV"]["CONFIG"][
+                "DANE_ES_HOST"
+            ],
+            "PROC_ENV.CONFIG.DANE_ES_PORT": config["PROC_ENV"]["CONFIG"][
+                "DANE_ES_PORT"
+            ],
+            "PROC_ENV.CONFIG.DANE_ES_INDEX": config["PROC_ENV"]["CONFIG"][
+                "DANE_ES_INDEX"
+            ],
+            "EXPORTER.CONFIG.DAAN_ES_HOST": config["EXPORTER"]["CONFIG"][
+                "DAAN_ES_HOST"
+            ],
+            "EXPORTER.CONFIG.DAAN_ES_PORT": config["EXPORTER"]["CONFIG"][
+                "DAAN_ES_PORT"
+            ],
+            "EXPORTER.CONFIG.DAAN_ES_INPUT_INDEX": config["EXPORTER"]["CONFIG"][
+                "DAAN_ES_INPUT_INDEX"
+            ],
+            "EXPORTER.CONFIG.DAAN_ES_OUTPUT_INDEX": config["EXPORTER"]["CONFIG"][
+                "DAAN_ES_OUTPUT_INDEX"
+            ],
+            "Definitions": statusDefinitionsURL,
         }
-        contextTexts = ['*{}*: {}'.format(key, value) for (key, value) in statusItems.items()]
-        contextText = '\n'.join(contextTexts)
+        contextTexts = [
+            "*{}*: {}".format(key, value) for (key, value) in statusItems.items()
+        ]
+        contextText = "\n".join(contextTexts)
         return {
-        "type": "context",
-        "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": contextText
-                }
-            ]
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": contextText}],
         }
-    
 
     def _format_status_info(self, status_info: dict):
         """Format the basis status information for slack
@@ -386,9 +395,7 @@ class SlackStatusMonitor(StatusMonitor):
         slack_status_info_list.append(
             self._create_markdown_fields_section_block(status_info)
         )
-        slack_status_info_list.append(
-            self._create_context_block(self.config)
-        )
+        slack_status_info_list.append(self._create_context_block(self.config))
 
         return slack_status_info_list
 
@@ -416,8 +423,10 @@ class SlackStatusMonitor(StatusMonitor):
         )
 
         if formatted_error_report:  # only upload error file if has content
-            datetimeNow = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-            filenameErrorReport = '{}-{}.json'.format(self.config["WORKFLOW_NAME"], datetimeNow)
+            datetimeNow = datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
+            filenameErrorReport = "{}-{}.json".format(
+                self.config["WORKFLOW_NAME"], datetimeNow
+            )
             slack_client.files_upload(
                 content=formatted_error_report,
                 filename=filenameErrorReport,
@@ -447,4 +456,3 @@ if __name__ == "__main__":
     status_handler = ExampleStatusHandler(config)
     status_monitor = SlackStatusMonitor(config, status_handler)
     status_monitor.monitor_status()
-    

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -345,28 +345,24 @@ class SlackStatusMonitor(StatusMonitor):
             "https://beng.slack.com/files/T03P55HJ9/F042WDNGD5W?origin_team=T03P55HJ9"
         )
         statusItems = {
-            "PROC_ENV.CONFIG.DANE_HOST": config["PROC_ENV"]["CONFIG"]["DANE_HOST"],
-            "PROC_ENV.CONFIG.DANE_ES_HOST": config["PROC_ENV"]["CONFIG"][
-                "DANE_ES_HOST"
-            ],
-            "PROC_ENV.CONFIG.DANE_ES_PORT": config["PROC_ENV"]["CONFIG"][
-                "DANE_ES_PORT"
-            ],
-            "PROC_ENV.CONFIG.DANE_ES_INDEX": config["PROC_ENV"]["CONFIG"][
-                "DANE_ES_INDEX"
-            ],
-            "EXPORTER.CONFIG.DAAN_ES_HOST": config["EXPORTER"]["CONFIG"][
-                "DAAN_ES_HOST"
-            ],
-            "EXPORTER.CONFIG.DAAN_ES_PORT": config["EXPORTER"]["CONFIG"][
-                "DAAN_ES_PORT"
-            ],
-            "EXPORTER.CONFIG.DAAN_ES_INPUT_INDEX": config["EXPORTER"]["CONFIG"][
-                "DAAN_ES_INPUT_INDEX"
-            ],
-            "EXPORTER.CONFIG.DAAN_ES_OUTPUT_INDEX": config["EXPORTER"]["CONFIG"][
-                "DAAN_ES_OUTPUT_INDEX"
-            ],
+            "PROC_ENV...DANE_HOST": "{}/manage".format(
+                config["PROC_ENV"]["CONFIG"]["DANE_HOST"]
+            ),
+            "PROC_ENV...DANE_ES_HOST": "http://{}:{}/{}".format(
+                config["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"],
+                config["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"],
+                config["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"],
+            ),
+            "EXPORTER...DAAN_ES_INPUT_INDEX": "http://{}:{}/{}".format(
+                config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
+                config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
+                config["EXPORTER"]["CONFIG"]["DAAN_ES_INPUT_INDEX"],
+            ),
+            "EXPORTER...DAAN_ES_OUTPUT_INDEX": "http://{}:{}/{}".format(
+                config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
+                config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
+                config["EXPORTER"]["CONFIG"]["DAAN_ES_OUTPUT_INDEX"],
+            ),
             "Definitions": statusDefinitionsURL,
         }
         contextTexts = [

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -344,27 +344,29 @@ class SlackStatusMonitor(StatusMonitor):
         statusDefinitionsURL = (
             "https://beng.slack.com/files/T03P55HJ9/F042WDNGD5W?origin_team=T03P55HJ9"
         )
-        statusItems = {
-            "PROC_ENV...DANE_HOST": "{}/manage".format(
-                config["PROC_ENV"]["CONFIG"]["DANE_HOST"]
-            ),
-            "PROC_ENV...DANE_ES_HOST": "http://{}:{}/{}".format(
-                config["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"],
-                config["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"],
-                config["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"],
-            ),
-            "EXPORTER...DAAN_ES_INPUT_INDEX": "http://{}:{}/{}".format(
-                config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
-                config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
-                config["EXPORTER"]["CONFIG"]["DAAN_ES_INPUT_INDEX"],
-            ),
-            "EXPORTER...DAAN_ES_OUTPUT_INDEX": "http://{}:{}/{}".format(
+        statusItems = {}
+        if config["PROC_ENV"]["TYPE"] == "dane_workflows.data_processing.DANEEnvironment":
+            statusItems["PROC_ENV...DANE_HOST"] = "{}/manage".format(
+                    config["PROC_ENV"]["CONFIG"]["DANE_HOST"]
+                )
+            statusItems["PROC_ENV...DANE_ES_HOST"] = "http://{}:{}/{}".format(
+                    config["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"],
+                    config["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"],
+                    config["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"],
+                )
+
+        statusItems["EXPORTER...DAAN_ES_INPUT_INDEX"] = "http://{}:{}/{}".format(
+                    config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
+                    config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
+                    config["EXPORTER"]["CONFIG"]["DAAN_ES_INPUT_INDEX"],
+                )
+        statusItems["EXPORTER...DAAN_ES_OUTPUT_INDEX"] = "http://{}:{}/{}".format(
                 config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
                 config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
                 config["EXPORTER"]["CONFIG"]["DAAN_ES_OUTPUT_INDEX"],
-            ),
-            "Definitions": statusDefinitionsURL,
-        }
+            )
+        statusItems["Definitions"]: statusDefinitionsURL
+
         contextTexts = [
             "*{}*: {}".format(key, value) for (key, value) in statusItems.items()
         ]

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -26,8 +26,8 @@ class StatusMonitor(ABC):
             else {}
         )
         # add PROC_ENV.CONFIG and EXPORTER.CONFIG as they contain relevant values for monitoring
-        self.config["PROC_ENV"] = config["PROC_ENV"]
-        self.config["EXPORTER"] = config["EXPORTER"]
+        self.proc_env_conf = config["PROC_ENV"]
+        self.export_conf = config["EXPORTER"]
 
         # enforce config validation
         if not self._validate_config():
@@ -42,13 +42,14 @@ class StatusMonitor(ABC):
             assert all(
                 [
                     x in self.config
-                    for x in ["INCLUDE_EXTRA_INFO", "PROC_ENV", "EXPORTER"]
+                    for x in ["TOKEN", "CHANNEL", "WORKFLOW_NAME","INCLUDE_EXTRA_INFO"]
                 ]
             ), "StatusMonitor config misses required fields"
 
             assert check_setting(
                 self.config["INCLUDE_EXTRA_INFO"], bool
             ), "StatusMonitor.INCLUDE_EXTRA_INFO not a bool"
+
 
         except AssertionError as e:
             logger.error(f"Configuration error: {str(e)}")
@@ -334,7 +335,7 @@ class SlackStatusMonitor(StatusMonitor):
         return {"type": "section", "fields": fields}
 
     @staticmethod
-    def _create_context_block(config):
+    def _create_context_block(self):
         """Add a block of type context containing a mrkdwn field listing relevant values from config
         Args:
         - contextText: a string containing markdown formatted text
@@ -345,25 +346,25 @@ class SlackStatusMonitor(StatusMonitor):
             "https://beng.slack.com/files/T03P55HJ9/F042WDNGD5W?origin_team=T03P55HJ9"
         )
         statusItems = {}
-        if config["PROC_ENV"]["TYPE"] == "dane_workflows.data_processing.DANEEnvironment":
+        if self.proc_env_conf["TYPE"] == "dane_workflows.data_processing.DANEEnvironment":
             statusItems["PROC_ENV...DANE_HOST"] = "{}/manage".format(
-                    config["PROC_ENV"]["CONFIG"]["DANE_HOST"]
+                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_HOST"]
                 )
             statusItems["PROC_ENV...DANE_ES_HOST"] = "http://{}:{}/{}".format(
-                    config["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"],
-                    config["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"],
-                    config["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"],
+                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"],
+                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"],
+                    self.proc_env_conf["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"],
                 )
 
         statusItems["EXPORTER...DAAN_ES_INPUT_INDEX"] = "http://{}:{}/{}".format(
-                    config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
-                    config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
-                    config["EXPORTER"]["CONFIG"]["DAAN_ES_INPUT_INDEX"],
+                    self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
+                    self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
+                    self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_INPUT_INDEX"],
                 )
         statusItems["EXPORTER...DAAN_ES_OUTPUT_INDEX"] = "http://{}:{}/{}".format(
-                config["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
-                config["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
-                config["EXPORTER"]["CONFIG"]["DAAN_ES_OUTPUT_INDEX"],
+                self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_HOST"],
+                self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_PORT"],
+                self.export_conf["EXPORTER"]["CONFIG"]["DAAN_ES_OUTPUT_INDEX"],
             )
         statusItems["Definitions"]: statusDefinitionsURL
 

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -11,6 +11,7 @@ from dane_workflows.status import (
     ErrorCode,
 )
 from dane_workflows.util.base_util import check_setting, load_config_or_die
+from datetime import datetime
 
 
 logger = logging.getLogger(__name__)
@@ -370,10 +371,13 @@ class SlackStatusMonitor(StatusMonitor):
         )
 
         if formatted_error_report:  # only upload error file if has content
+            datetimeNow = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+            filenameErrorReport = '{}-{}.json'.format(self.config["WORKFLOW_NAME"], datetimeNow)
             slack_client.files_upload(
                 content=formatted_error_report,
+                filename=filenameErrorReport,
                 channels=[self.config["CHANNEL"]],
-                initial_comment="For more details, review this error file",
+                initial_comment="*Error file* (based on current status database)",
             )
 
     def monitor_status(self):

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -309,9 +309,15 @@ class SlackStatusMonitor(StatusMonitor):
                 case int() as value:
                     text = f"*{key}:*\n{value}"
                 case {} as value:
-                    text = f"*{key}:*\nN/A"
+                    if 'error' in key.lower():
+                        text = f"*{key}:*\nN/A :large_green_circle:"
+                    else:
+                        text = f"*{key}:*\nN/A"
                 case dict() as value:
-                    text = f"*{key}:*\n"
+                    if 'error' in key.lower():
+                        text = f"*{key}:*\n:red_circle:\n"
+                    else:
+                        text = f"*{key}:*\n"
                     for status_or_error, count in value.items():
                         text += f"{status_or_error}: {count}\n"
                 case _:

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -40,8 +40,8 @@ class StatusMonitor(ABC):
 
         try:
             assert all(
-                [x in self.config for x in ["INCLUDE_EXTRA_INFO"]]
-            ), "StatusMonitor.INCLUDE_EXTRA_INFO missing"
+                [x in self.config for x in ["INCLUDE_EXTRA_INFO", "PROC_ENV", "EXPORTER"]]
+            ), "StatusMonitor config misses required fields"
 
             assert check_setting(
                 self.config["INCLUDE_EXTRA_INFO"], bool

--- a/dane_workflows/status_monitor.py
+++ b/dane_workflows/status_monitor.py
@@ -444,7 +444,7 @@ if __name__ == "__main__":
 
     config = load_config_or_die(
         "../config-example.yml"
-    )  # TODO: how do we get this to work from within a workflow with the correct config?
+    )
     status_handler = ExampleStatusHandler(config)
     data_processing_env = ExampleDataProcessingEnvironment(config, status_handler)
     exporter = ExampleExporter(config, status_handler)

--- a/dane_workflows/task_scheduler.py
+++ b/dane_workflows/task_scheduler.py
@@ -72,7 +72,7 @@ class TaskScheduler(object):
         self.status_monitor = None
         if status_monitor:
             self.status_monitor = status_monitor(
-                config, self.status_handler
+                config, self.status_handler, self.data_processing_env, self.exporter
             )  # optional monitoring
 
     def _validate_config(self):

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -36,3 +36,47 @@ def slack_monitor_config():
     config["STATUS_MONITOR"]["CONFIG"]["WORKFLOW_NAME"] = "TESTING"
     config["STATUS_MONITOR"]["CONFIG"]["INCLUDE_EXTRA_INFO"] = False
     return config
+
+
+@pytest.fixture
+def dane_data_processing_config():
+    config = load_config_or_die(
+        relative_from_file(__file__, "../../config-unit-test.yml")
+    )
+    config["PROC_ENV"]["TYPE"] = "dane_workflows.data_processing.DANEEnvironment"
+    config["PROC_ENV"]["CONFIG"] = {}
+    config["PROC_ENV"]["CONFIG"]["DANE_HOST"] = "your-dane-host"
+    config["PROC_ENV"]["CONFIG"]["DANE_ES_HOST"] = "your-dane-es-host"
+    config["PROC_ENV"]["CONFIG"]["DANE_ES_PORT"] = 80
+    config["PROC_ENV"]["CONFIG"]["DANE_ES_INDEX"] = "your-dane-index"
+    config["PROC_ENV"]["CONFIG"]["DANE_TASK_ID"] = "DOWNLOAD"
+    config["PROC_ENV"]["CONFIG"]["DANE_STATUS_DIR"] = "some-status-dir"
+    config["PROC_ENV"]["CONFIG"]["DANE_MONITOR_INTERVAL"] = 3
+    config["PROC_ENV"]["CONFIG"]["DANE_BATCH_PREFIX"] = "dummy"
+    config["PROC_ENV"]["CONFIG"]["DANE_ES_QUERY_TIMEOUT"] = 20
+
+    return config
+
+
+@pytest.fixture
+def example_processing_config():
+    config = load_config_or_die(
+        relative_from_file(__file__, "../../config-unit-test.yml")
+    )
+    config["PROC_ENV"]["TYPE"] = "dane_workflows.data_processing.ExampleDataProcessingEnvironment"
+    config["PROC_ENV"]["CONFIG"] = {}
+    config["PROC_ENV"]["CONFIG"]["EXAMPLE_KEY"] = "example_value"
+    return config
+
+
+@pytest.fixture
+def example_exporter_config():
+    config = load_config_or_die(
+            relative_from_file(__file__, "../../config-unit-test.yml")
+            )
+    config["EXPORTER"]["TYPE"] = "dane_workflows.exporter.ExampleExporter"
+    config["EXPORTER"]["DAAN_ES_HOST"] = "dummy_es_host"
+    config["EXPORTER"]["DAAN_ES_PORT"] = 0
+    config["EXPORTER"]["DAAN_ES_OUTPUT_INDEX"] = "dummy_es_input_index"
+    config["EXPORTER"]["DAAN_ES_INPUT_INDEX"] = "dummy_es_output_index"
+    return config

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -63,7 +63,9 @@ def example_processing_config():
     config = load_config_or_die(
         relative_from_file(__file__, "../../config-unit-test.yml")
     )
-    config["PROC_ENV"]["TYPE"] = "dane_workflows.data_processing.ExampleDataProcessingEnvironment"
+    config["PROC_ENV"][
+        "TYPE"
+    ] = "dane_workflows.data_processing.ExampleDataProcessingEnvironment"
     config["PROC_ENV"]["CONFIG"] = {}
     config["PROC_ENV"]["CONFIG"]["EXAMPLE_KEY"] = "example_value"
     return config
@@ -72,8 +74,8 @@ def example_processing_config():
 @pytest.fixture
 def example_exporter_config():
     config = load_config_or_die(
-            relative_from_file(__file__, "../../config-unit-test.yml")
-            )
+        relative_from_file(__file__, "../../config-unit-test.yml")
+    )
     config["EXPORTER"]["TYPE"] = "dane_workflows.exporter.ExampleExporter"
     config["EXPORTER"]["DAAN_ES_HOST"] = "dummy_es_host"
     config["EXPORTER"]["DAAN_ES_PORT"] = 0

--- a/tests/unit_tests/data_processing_test.py
+++ b/tests/unit_tests/data_processing_test.py
@@ -96,17 +96,31 @@ def test_monitor_batch(config, proc_batch_id):
         unstub()
 
 
-@pytest.mark.parametrize(('conf_number', 'output'), ([
-    (0,
-        {"PROC_ENV...DANE_HOST" : "your-dane-host/manage",
-         "PROC_ENV...DANE_ES_HOST" : "http://your-dane-es-host:80/your-dane-index"}),
-    (1,
-        {"EXAMPLE_KEY" : "example_value"})
-    ]))
-def test_get_pretty_processing_conf_vars(conf_number, output, dane_data_processing_config, example_processing_config):
+@pytest.mark.parametrize(
+    ("conf_number", "output"),
+    (
+        [
+            (
+                0,
+                {
+                    "PROC_ENV...DANE_HOST": "your-dane-host/manage",
+                    "PROC_ENV...DANE_ES_HOST": "http://your-dane-es-host:80/your-dane-index",
+                },
+            ),
+            (1, {"EXAMPLE_KEY": "example_value"}),
+        ]
+    ),
+)
+def test_get_pretty_processing_conf_vars(
+    conf_number, output, dane_data_processing_config, example_processing_config
+):
     configs_to_use = [dane_data_processing_config, example_processing_config]
     status_handler = ExampleStatusHandler(configs_to_use[conf_number])
-    data_processing_env_class = import_dane_workflow_class(configs_to_use[conf_number]["PROC_ENV"]["TYPE"])
+    data_processing_env_class = import_dane_workflow_class(
+        configs_to_use[conf_number]["PROC_ENV"]["TYPE"]
+    )
     print(configs_to_use[conf_number])
-    data_processing_env = data_processing_env_class(configs_to_use[conf_number], status_handler)
+    data_processing_env = data_processing_env_class(
+        configs_to_use[conf_number], status_handler
+    )
     assert data_processing_env.get_pretty_processing_conf_vars() == output

--- a/tests/unit_tests/data_processing_test.py
+++ b/tests/unit_tests/data_processing_test.py
@@ -111,7 +111,7 @@ def test_monitor_batch(config, proc_batch_id):
         ]
     ),
 )
-def test_get_pretty_processing_conf_vars(
+def test_get_pretty_config(
     conf_number, output, dane_data_processing_config, example_processing_config
 ):
     configs_to_use = [dane_data_processing_config, example_processing_config]
@@ -123,4 +123,4 @@ def test_get_pretty_processing_conf_vars(
     data_processing_env = data_processing_env_class(
         configs_to_use[conf_number], status_handler
     )
-    assert data_processing_env.get_pretty_processing_conf_vars() == output
+    assert data_processing_env.get_pretty_config() == output

--- a/tests/unit_tests/data_processing_test.py
+++ b/tests/unit_tests/data_processing_test.py
@@ -1,8 +1,11 @@
 from mockito import unstub, when, ANY, verify, spy2
 import pytest
 import sys
+
 from dane_workflows.data_processing import ExampleDataProcessingEnvironment
 from dane_workflows.status import ExampleStatusHandler, ProcessingStatus, ErrorCode
+from dane_workflows.util.base_util import import_dane_workflow_class
+
 from test_util import new_batch
 
 
@@ -91,3 +94,19 @@ def test_monitor_batch(config, proc_batch_id):
         assert dpe is not None
     finally:
         unstub()
+
+
+@pytest.mark.parametrize(('conf_number', 'output'), ([
+    (0,
+        {"PROC_ENV...DANE_HOST" : "your-dane-host/manage",
+         "PROC_ENV...DANE_ES_HOST" : "http://your-dane-es-host:80/your-dane-index"}),
+    (1,
+        {"EXAMPLE_KEY" : "example_value"})
+    ]))
+def test_get_pretty_processing_conf_vars(conf_number, output, dane_data_processing_config, example_processing_config):
+    configs_to_use = [dane_data_processing_config, example_processing_config]
+    status_handler = ExampleStatusHandler(configs_to_use[conf_number])
+    data_processing_env_class = import_dane_workflow_class(configs_to_use[conf_number]["PROC_ENV"]["TYPE"])
+    print(configs_to_use[conf_number])
+    data_processing_env = data_processing_env_class(configs_to_use[conf_number], status_handler)
+    assert data_processing_env.get_pretty_processing_conf_vars() == output

--- a/tests/unit_tests/exporter_test.py
+++ b/tests/unit_tests/exporter_test.py
@@ -4,8 +4,11 @@ from dane_workflows.util.base_util import import_dane_workflow_class
 
 def test_get_pretty_export_conf_vars(example_exporter_config):
     status_handler = ExampleStatusHandler(example_exporter_config)
-    exporter_class = import_dane_workflow_class(example_exporter_config["EXPORTER"]["TYPE"])
+    exporter_class = import_dane_workflow_class(
+        example_exporter_config["EXPORTER"]["TYPE"]
+    )
     exporter = exporter_class(example_exporter_config, status_handler)
     assert exporter.get_pretty_export_conf_vars() == {
-        "EXPORTER...DAAN_ES_INPUT_INDEX" : "http://dummy_es_host:0/dummy_es_input_index",
-        "EXPORTER...DAAN_ES_OUTPUT_INDEX" : "http://dummy_es_host:0/dummy_es_output_index"}
+        "EXPORTER...DAAN_ES_INPUT_INDEX": "http://dummy_es_host:0/dummy_es_input_index",
+        "EXPORTER...DAAN_ES_OUTPUT_INDEX": "http://dummy_es_host:0/dummy_es_output_index",
+    }

--- a/tests/unit_tests/exporter_test.py
+++ b/tests/unit_tests/exporter_test.py
@@ -1,0 +1,11 @@
+from dane_workflows.status import ExampleStatusHandler
+from dane_workflows.util.base_util import import_dane_workflow_class
+
+
+def test_get_pretty_export_conf_vars(example_exporter_config):
+    status_handler = ExampleStatusHandler(example_exporter_config)
+    exporter_class = import_dane_workflow_class(example_exporter_config["EXPORTER"]["TYPE"])
+    exporter = exporter_class(example_exporter_config, status_handler)
+    assert exporter.get_pretty_export_conf_vars() == {
+        "EXPORTER...DAAN_ES_INPUT_INDEX" : "http://dummy_es_host:0/dummy_es_input_index",
+        "EXPORTER...DAAN_ES_OUTPUT_INDEX" : "http://dummy_es_host:0/dummy_es_output_index"}

--- a/tests/unit_tests/exporter_test.py
+++ b/tests/unit_tests/exporter_test.py
@@ -2,13 +2,13 @@ from dane_workflows.status import ExampleStatusHandler
 from dane_workflows.util.base_util import import_dane_workflow_class
 
 
-def test_get_pretty_export_conf_vars(example_exporter_config):
+def test_get_pretty_config(example_exporter_config):
     status_handler = ExampleStatusHandler(example_exporter_config)
     exporter_class = import_dane_workflow_class(
         example_exporter_config["EXPORTER"]["TYPE"]
     )
     exporter = exporter_class(example_exporter_config, status_handler)
-    assert exporter.get_pretty_export_conf_vars() == {
+    assert exporter.get_pretty_config() == {
         "EXPORTER...DAAN_ES_INPUT_INDEX": "http://dummy_es_host:0/dummy_es_input_index",
         "EXPORTER...DAAN_ES_OUTPUT_INDEX": "http://dummy_es_host:0/dummy_es_output_index",
     }

--- a/tests/unit_tests/status_monitor_test.py
+++ b/tests/unit_tests/status_monitor_test.py
@@ -416,7 +416,7 @@ def test_monitor_status(config, include_extra_info):
         dummy_formatted_status_info, dummy_formatted_status_report
     ):
 
-        status_monitor._monitor_status()
+        status_monitor.monitor_status()
 
         verify(status_monitor, times=1)._check_status()
         verify(status_monitor, times=1)._get_detailed_status_report(

--- a/tests/unit_tests/status_monitor_test.py
+++ b/tests/unit_tests/status_monitor_test.py
@@ -360,7 +360,7 @@ def test_monitor_status(config, include_extra_info):
         dummy_formatted_status_info, dummy_formatted_error_report
     ):
 
-        status_monitor.monitor_status()
+        status_monitor._monitor_status()
 
         verify(status_monitor, times=1)._check_status()
         verify(status_monitor, times=1)._get_detailed_status_report(

--- a/tests/unit_tests/status_monitor_test.py
+++ b/tests/unit_tests/status_monitor_test.py
@@ -20,7 +20,9 @@ def test__check_status(config):
     status_handler = ExampleStatusHandler(config)
     data_processing_env = ExampleDataProcessingEnvironment
     exporter = ExampleExporter
-    status_monitor = ExampleStatusMonitor(config, status_handler, data_processing_env, exporter)
+    status_monitor = ExampleStatusMonitor(
+        config, status_handler, data_processing_env, exporter
+    )
     dummy_last_proc_batch_id = 1
     dummy_last_source_batch_id = 2
 
@@ -122,7 +124,9 @@ def test__get_detailed_status_report(config, include_extra_info):
     status_handler = ExampleStatusHandler(config)
     data_processing_env = ExampleDataProcessingEnvironment(config, status_handler)
     exporter = ExampleExporter(config, status_handler)
-    status_monitor = ExampleStatusMonitor(config, status_handler, data_processing_env, exporter)
+    status_monitor = ExampleStatusMonitor(
+        config, status_handler, data_processing_env, exporter
+    )
 
     dummy_incomplete = ["dummy-incomplete-1", "dummy-incomplete-2"]
     dummy_complete = [
@@ -260,9 +264,13 @@ def test_validate_config(
 
     if expect_error:
         with pytest.raises(SystemExit):
-            SlackStatusMonitor(config_to_validate, status_handler, data_processing_env, exporter)
+            SlackStatusMonitor(
+                config_to_validate, status_handler, data_processing_env, exporter
+            )
     else:
-        assert SlackStatusMonitor(config_to_validate, status_handler, data_processing_env, exporter)
+        assert SlackStatusMonitor(
+            config_to_validate, status_handler, data_processing_env, exporter
+        )
 
 
 @pytest.mark.parametrize(
@@ -276,25 +284,50 @@ def test_validate_config(
                     "STATUS INFO 2": 4,
                 },
             },
-            [{'type': 'divider'},
-             {'text': {'text': '*Status report for workflow*:\nTESTING', 'type': 'mrkdwn'}, 'type': 'section'},
-             {'fields': [{'text': '*Last batch processed:*\n12345', 'type': 'mrkdwn'},
-                         {'text': '*Status information for last batch processed:*\nN/A',
-                          'type': 'mrkdwn'}],
-              'type': 'section'},
-             {'elements': [{'text': '*EXPORTER...DAAN_ES_INPUT_INDEX*: '
-                                    'http://dummy_es_host:0/dummy_es_input_index\n'
-                                    '*EXPORTER...DAAN_ES_OUTPUT_INDEX*: '
-                                    'http://dummy_es_host:0/dummy_es_output_index',
-                                    'type': 'mrkdwn'}],
-              'type': 'context'}])
+            [
+                {"type": "divider"},
+                {
+                    "text": {
+                        "text": "*Status report for workflow*:\nTESTING",
+                        "type": "mrkdwn",
+                    },
+                    "type": "section",
+                },
+                {
+                    "fields": [
+                        {"text": "*Last batch processed:*\n12345", "type": "mrkdwn"},
+                        {
+                            "text": "*Status information for last batch processed:*\nN/A",
+                            "type": "mrkdwn",
+                        },
+                    ],
+                    "type": "section",
+                },
+                {
+                    "elements": [
+                        {
+                            "text": "*EXPORTER...DAAN_ES_INPUT_INDEX*: "
+                            "http://dummy_es_host:0/dummy_es_input_index\n"
+                            "*EXPORTER...DAAN_ES_OUTPUT_INDEX*: "
+                            "http://dummy_es_host:0/dummy_es_output_index",
+                            "type": "mrkdwn",
+                        }
+                    ],
+                    "type": "context",
+                },
+            ],
+        )
     ],
 )
 def test_format_status_info(slack_monitor_config, status_info: dict, expected_output):
     status_handler = ExampleStatusHandler(slack_monitor_config)
-    data_processing_env = ExampleDataProcessingEnvironment(slack_monitor_config, status_handler)
+    data_processing_env = ExampleDataProcessingEnvironment(
+        slack_monitor_config, status_handler
+    )
     exporter = ExampleExporter(slack_monitor_config, status_handler)
-    slack_status_monitor = SlackStatusMonitor(slack_monitor_config, status_handler, data_processing_env, exporter)
+    slack_status_monitor = SlackStatusMonitor(
+        slack_monitor_config, status_handler, data_processing_env, exporter
+    )
     status_info_list = slack_status_monitor._format_status_info(status_info)
     assert type(status_info_list) == list
     assert status_info_list == expected_output
@@ -313,11 +346,14 @@ def test__send_status(config, formatted_status_report):
         "WORKFLOW_NAME": "a workflow name",
         "INCLUDE_EXTRA_INFO": False,
     }
-    status_monitor = SlackStatusMonitor(config, status_handler, data_processing_env, exporter)
+    status_monitor = SlackStatusMonitor(
+        config, status_handler, data_processing_env, exporter
+    )
     dummy_formatted_status = "dummy formatted status"
 
     with when(slack_sdk.WebClient).chat_postMessage(
-        channel=ANY, blocks=dummy_formatted_status,
+        channel=ANY,
+        blocks=dummy_formatted_status,
     ), when(slack_sdk.WebClient).files_upload(
         content=formatted_status_report, channels=ANY, filename=ANY, initial_comment=ANY
     ):
@@ -325,12 +361,16 @@ def test__send_status(config, formatted_status_report):
         status_monitor._send_status(dummy_formatted_status, formatted_status_report)
 
         verify(slack_sdk.WebClient, times=1).chat_postMessage(
-            channel=ANY, blocks=dummy_formatted_status,
+            channel=ANY,
+            blocks=dummy_formatted_status,
         )
         verify(
             slack_sdk.WebClient, times=1 if formatted_status_report else 0
         ).files_upload(
-            content=formatted_status_report, filename=ANY, channels=ANY, initial_comment=ANY
+            content=formatted_status_report,
+            filename=ANY,
+            channels=ANY,
+            initial_comment=ANY,
         )
 
 
@@ -345,7 +385,9 @@ def test_monitor_status(config, include_extra_info):
         "WORKFLOW_NAME": "a workflow name",
         "INCLUDE_EXTRA_INFO": include_extra_info,
     }
-    status_monitor = SlackStatusMonitor(config, status_handler, data_processing_env, exporter)
+    status_monitor = SlackStatusMonitor(
+        config, status_handler, data_processing_env, exporter
+    )
 
     dummy_status = {"dummy-key": "dummy-value"}
     dummy_satus_report = {"dummy-error-key": "dummy-error-value"}

--- a/tests/unit_tests/status_monitor_test.py
+++ b/tests/unit_tests/status_monitor_test.py
@@ -291,9 +291,9 @@ def test_format_status_info(slack_monitor_config, status_info: dict, expected_ou
 
 
 @pytest.mark.parametrize(
-    "formatted_error_report", [None, "a formatted error report string"]
+    "formatted_status_report", [None, "a formatted satus report string"]
 )
-def test__send_status(config, formatted_error_report):
+def test__send_status(config, formatted_status_report):
     status_handler = ExampleStatusHandler(config)
     config["STATUS_MONITOR"]["CONFIG"] = {
         "TOKEN": "a token",
@@ -307,18 +307,18 @@ def test__send_status(config, formatted_error_report):
     with when(slack_sdk.WebClient).chat_postMessage(
         channel=ANY, blocks=dummy_formatted_status,
     ), when(slack_sdk.WebClient).files_upload(
-        content=formatted_error_report, channels=ANY, filename=ANY, initial_comment=ANY
+        content=formatted_status_report, channels=ANY, filename=ANY, initial_comment=ANY
     ):
 
-        status_monitor._send_status(dummy_formatted_status, formatted_error_report)
+        status_monitor._send_status(dummy_formatted_status, formatted_status_report)
 
         verify(slack_sdk.WebClient, times=1).chat_postMessage(
             channel=ANY, blocks=dummy_formatted_status,
         )
         verify(
-            slack_sdk.WebClient, times=1 if formatted_error_report else 0
+            slack_sdk.WebClient, times=1 if formatted_status_report else 0
         ).files_upload(
-            content=formatted_error_report, filename=ANY, channels=ANY, initial_comment=ANY
+            content=formatted_status_report, filename=ANY, channels=ANY, initial_comment=ANY
         )
 
 
@@ -334,14 +334,14 @@ def test_monitor_status(config, include_extra_info):
     status_monitor = SlackStatusMonitor(config, status_handler)
 
     dummy_status = {"dummy-key": "dummy-value"}
-    dummy_error_report = {"dummy-error-key": "dummy-error-value"}
+    dummy_satus_report = {"dummy-error-key": "dummy-error-value"}
     dummy_formatted_status_info = "dummy formatted info"
-    dummy_formatted_error_report = "dummy formatted error report"
+    dummy_formatted_status_report = "dummy formatted error report"
 
     with when(status_monitor)._check_status().thenReturn(dummy_status), when(
         status_monitor
     )._get_detailed_status_report(include_extra_info=include_extra_info).thenReturn(
-        dummy_error_report
+        dummy_satus_report
     ), when(
         status_monitor
     )._format_status_info(
@@ -350,14 +350,14 @@ def test_monitor_status(config, include_extra_info):
         dummy_formatted_status_info
     ), when(
         status_monitor
-    )._format_error_report(
-        dummy_error_report
+    )._format_status_report(
+        dummy_satus_report
     ).thenReturn(
-        dummy_formatted_error_report
+        dummy_formatted_status_report
     ), when(
         status_monitor
     )._send_status(
-        dummy_formatted_status_info, dummy_formatted_error_report
+        dummy_formatted_status_info, dummy_formatted_status_report
     ):
 
         status_monitor._monitor_status()
@@ -367,7 +367,7 @@ def test_monitor_status(config, include_extra_info):
             include_extra_info=include_extra_info
         )
         verify(status_monitor, times=1)._format_status_info(dummy_status)
-        verify(status_monitor, times=1)._format_error_report(dummy_error_report)
+        verify(status_monitor, times=1)._format_status_report(dummy_satus_report)
         verify(status_monitor, times=1)._send_status(
-            dummy_formatted_status_info, dummy_formatted_error_report
+            dummy_formatted_status_info, dummy_formatted_status_report
         )

--- a/tests/unit_tests/status_monitor_test.py
+++ b/tests/unit_tests/status_monitor_test.py
@@ -74,7 +74,7 @@ def test__check_status(config):
         status_info = status_monitor._check_status()
 
         assert status_info["Last batch processed"] == dummy_last_proc_batch_id
-        assert status_info["Last source batch retrieved"] == dummy_last_source_batch_id
+        assert status_info["Last src batch retrieved"] == dummy_last_source_batch_id
 
         for key in dummy_status_counts_for_proc_batch:
             assert (
@@ -268,26 +268,18 @@ def test_validate_config(
                     "STATUS INFO 2": 4,
                 },
             },
-            [
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": "*TESTING STATUS REPORT*"},
-                },
-                {"type": "divider"},
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": "*Last batch processed*: 12345"},
-                },
-                {"type": "divider"},
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "*Status information for last batch processed*\nSTATUS INFO 1: 12\nSTATUS INFO 2: 4\n",
-                    },
-                },
-            ],
-        )
+            [{'type': 'divider'},
+             {'text': {'text': '*Status report for workflow*:\nTESTING', 'type': 'mrkdwn'}, 'type': 'section'},
+             {'fields': [{'text': '*Last batch processed:*\n12345', 'type': 'mrkdwn'},
+                         {'text': '*Status information for last batch processed:*\nN/A',
+                          'type': 'mrkdwn'}],
+              'type': 'section'},
+             {'elements': [{'text': '*EXPORTER...DAAN_ES_INPUT_INDEX*: '
+                                    'http://dummy_es_host:0/dummy_es_input_index\n'
+                                    '*EXPORTER...DAAN_ES_OUTPUT_INDEX*: '
+                                    'http://dummy_es_host:0/dummy_es_output_index',
+                                    'type': 'mrkdwn'}],
+              'type': 'context'}])
     ],
 )
 def test_format_status_info(slack_monitor_config, status_info: dict, expected_output):
@@ -313,20 +305,20 @@ def test__send_status(config, formatted_error_report):
     dummy_formatted_status = "dummy formatted status"
 
     with when(slack_sdk.WebClient).chat_postMessage(
-        channel=ANY, blocks=dummy_formatted_status, icon_emoji=ANY
+        channel=ANY, blocks=dummy_formatted_status,
     ), when(slack_sdk.WebClient).files_upload(
-        content=formatted_error_report, channels=ANY, initial_comment=ANY
+        content=formatted_error_report, channels=ANY, filename=ANY, initial_comment=ANY
     ):
 
         status_monitor._send_status(dummy_formatted_status, formatted_error_report)
 
         verify(slack_sdk.WebClient, times=1).chat_postMessage(
-            channel=ANY, blocks=dummy_formatted_status, icon_emoji=ANY
+            channel=ANY, blocks=dummy_formatted_status,
         )
         verify(
             slack_sdk.WebClient, times=1 if formatted_error_report else 0
         ).files_upload(
-            content=formatted_error_report, channels=ANY, initial_comment=ANY
+            content=formatted_error_report, filename=ANY, channels=ANY, initial_comment=ANY
         )
 
 


### PR DESCRIPTION
fixes https://github.com/beeldengeluid/dane-workflows/issues/13

To test:
- get an appropriate proc_stats db (Philo can help)
- get an appropriate config-example.yaml (Philo can help)
- in `/dane_workflows/` run `python status_monitor.py`
- check that you get expected results displayed in the Slack Channel that is configured in the config, without errors 
- run `scripts/check-project.sh`

NB: some things I would love a reviewer's perspective on:

1. 20 unit tests are failing, I haven't had time to look into this yet
2. not sure if passing PROC_ENV & EXPORTER config values along with status monitor config if the cleanest approach, see https://github.com/beeldengeluid/dane-workflows/commit/365290f6b2c6cb743d712e0446eaabe430bc5bb4
3. the validation of expected config values could be more rigorous, but I have left that for a later enhancement, see https://github.com/beeldengeluid/dane-workflows/commit/12c7b50a70af40b8ddb1f2b9b8b2eff69ea515dc