### PR TITLE
added checks to verify ES vs status_row membership

### DIFF
--- a/dane_workflows/data_provider.py
+++ b/dane_workflows/data_provider.py
@@ -74,7 +74,9 @@ class DataProvider(ABC):
             new_source_batch = self.fetch_source_batch_data(
                 self.status_handler.get_cur_source_batch_id() + 1
             )
-            logger.info(f"New source_batch is ok: {new_source_batch is not None}")
+            logger.info(
+                f"New source_batch is ok: {new_source_batch is not None}"
+            )  # could be []
             if new_source_batch:  # make the StatusHandler track the new batch
                 if called_recursively:
                     # we have a problem, as we are in an infinite loop


### PR DESCRIPTION
Improve robustness in case the DANE (ES) status is out of sync with the status_rows (of the dane-workflows)

context:

```
Er stonden nog tasks queued in ES, maar die waren niet meer queued, omdat
de HUC ASR workers opnieuw opgestart waren. 

Hierdoor bleef dane-workflows-daan-asr-huc eeuwig wachten
```